### PR TITLE
Adds a fully elaborated enforcement guide. Closes #11

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -45,6 +45,10 @@ export default defineConfig({
               label: "Running your Policy",
               slug: "getting-started/running-your-policy",
             },
+            {
+              label: "Policy Enforcement",
+              slug: "getting-started/enforcement",
+            },
           ],
         },
         {

--- a/src/content/docs/getting-started/enforcement.md
+++ b/src/content/docs/getting-started/enforcement.md
@@ -1,0 +1,74 @@
+---
+title: Enforcement
+description: Enforcing policies using Sentrie
+---
+
+## Enforcement is external
+
+Sentrie is a **deterministic policy decision engine**. It evaluates structured inputs against rules and returns `true`, `false`, or `unknown`. That's it.
+
+The engine is **pure** and **side-effect-free**—no mutations, no API calls, no state changes. This makes it safe to embed deep in your stack: IAM systems, API gateways, control planes, multi-tenant services, anywhere you need fast, reliable authorization decisions.
+
+Because enforcement lives outside the policy, the same rules work across different systems with different enforcement modes - whether you're blocking requests, redacting data, or triggering step-up auth.
+
+:::note[Sentrie makes decisions]
+Sentrie focuses on **decision quality** — your systems handle enforcement.
+:::
+
+## Why Enforcement is External
+
+Different platforms enforce differently:
+
+- **IAM layers** allow, deny, or escalate auth flows
+- **API gateways** throttle, rate-limit, or block routes
+- **Multi-tenant systems** control features and per-org limits
+- **Security layers** trigger reviews or step-up verification
+- **Backend services** serve, redact, or transform data
+
+Keeping the engine pure gives you three guarantees:
+
+- **Determinism** — same input = same output, always
+- **Reproducibility** — decisions are safe to replay and audit
+- **Portability** — runs identically everywhere
+
+This is what makes Sentrie safe for **real-time**, **latency-sensitive** paths.
+
+## How It Works
+
+Call Sentrie's HTTP endpoint with context. Get a decision. **Enforce it**.
+
+```bash
+curl -X POST https://sentrie.host:7529/decision/namespace/policy/rule \
+  -H "Content-Type: application/json" \
+  -d '{
+    "facts": {
+      "user": "...",
+      "org": "...",
+      "roles": ["..."],
+      "plan": "pro"
+    }
+  }'
+```
+
+What happens next is up to you:
+
+- Backends accept, reject, or redact responses
+- IAM systems allow, deny, or trigger step-up auth
+- Gateways block, throttle, or downgrade routes
+- Feature gates enable, disable, or shadow-test features
+- Entitlement systems enforce quotas or usage limits
+- Data layers redact fields before returning them
+
+:::note[Philosophy]
+Sentrie supplies truth. Systems apply consequences.
+:::
+
+## Why This Works
+
+Separating decision from action makes Sentrie:
+
+- Safe for critical paths
+- Consistent across systems
+- Easy to test and replay
+- Independently scalable
+- Flexible for different enforcement modes


### PR DESCRIPTION
- Rebuilt `src/content/docs/getting-started/enforcement.md` into a narrative-style guide that explains what Sentrie is, what it is not, and how decisions stay pure and deterministic.
- Detailed why enforcement intentionally lives outside Sentrie, including environment-specific examples, determinism benefits, and alignment with proven industry architectures.
- Added practical guidance for implementing enforcement via SDKs, HTTP endpoints, custom integrations, and automation pipelines, plus the advantages of keeping the boundary clean.