### PR TITLE
Add documentation for Homebrew Formula installation method. Closes #18

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 When you make any changes, update the `PR_DESCRIPTION.md` file to describe the changes you made. The content of the file should be in markdown format. The file should be named `PR_DESCRIPTION.md` and should be placed in the root of the project. If you find existing content in the file that contradicts the changes you have made, overwrite the existing content. The file will be used to generate the pull request description.
 
-The title in the @PR_DESCRIPTION.md file should be such that it completes the sentence: "If merged, this pull request will ...". Keep it below 60 words. You may use markdown formatting.
+The title in the `PR_DESCRIPTION.md` file should be such that it completes the sentence: "If merged, this pull request will ...". Keep it below 60 words. You may use markdown formatting.
 
 Make sure that all sources files have the correct license headers.

--- a/src/content/docs/getting-started/installation.md
+++ b/src/content/docs/getting-started/installation.md
@@ -13,17 +13,13 @@ Convenience scripts are provided for macOS, Linux, and Windows.
 
 ### On macOS
 
-**Recommended: Homebrew Formula** (reduces Gatekeeper friction)
+**Recommended: Homebrew Formula**
 
 ```bash
 brew install sentrie-sh/tap/sentrie
 ```
 
-**Alternative: Homebrew Cask**
-
-```bash
-brew install --cask sentrie-sh/tap/sentrie
-```
+> **Why Formulas instead of Casks?** macOS Gatekeeper flags binaries installed via Homebrew Casks, requiring users to manually remove quarantine attributes or approve the binary in System Settings. Formulas are treated as regular binaries by Gatekeeper, avoiding these security warnings and providing a seamless installation experience.
 
 **Alternative: Install script**
 

--- a/src/content/docs/getting-started/installation.md
+++ b/src/content/docs/getting-started/installation.md
@@ -11,7 +11,27 @@ Convenience scripts are provided for macOS, Linux, and Windows.
 
 ## Installing the latest version
 
-### On macOS, Linux and WSL2
+### On macOS
+
+**Recommended: Homebrew Formula** (reduces Gatekeeper friction)
+
+```bash
+brew install sentrie-sh/tap/sentrie
+```
+
+**Alternative: Homebrew Cask**
+
+```bash
+brew install --cask sentrie-sh/tap/sentrie
+```
+
+**Alternative: Install script**
+
+```bash
+curl -fsSL https://sentrie.sh/install.sh | bash
+```
+
+### On Linux and WSL2
 
 ```bash
 curl -fsSL https://sentrie.sh/install.sh | bash
@@ -33,7 +53,15 @@ This should display the current version of Sentrie.
 
 ## Installing a specific version
 
-### On macOS, Linux and WSL2
+### On macOS
+
+For specific versions, use the install script:
+
+```bash
+curl -fsSL https://sentrie.sh/install.sh | bash -s v0.1.0
+```
+
+### On Linux and WSL2
 
 ```bash
 curl -fsSL https://sentrie.sh/install.sh | bash -s v0.1.0


### PR DESCRIPTION

## Summary

This PR updates the installation documentation to remove Homebrew Cask as an installation option and explains why we moved away from Casks. macOS Gatekeeper flags binaries installed via Casks, requiring users to manually remove quarantine attributes or approve binaries in System Settings. Formulas are treated as regular binaries by Gatekeeper, avoiding these security warnings.

**Key Changes:**

- **Installation Documentation Update** (`src/content/docs/getting-started/installation.md`):
  - Removed "Alternative: Homebrew Cask" section
  - Added explanation for why only Formulas are supported
  - Updated Formula recommendation note to remove "(reduces Gatekeeper friction)" since Cask is no longer an option
  - Explained that macOS Gatekeeper flags binaries installed via Casks, requiring workarounds
  - Noted that Formulas are treated as regular binaries by Gatekeeper, providing a better user experience

**Benefits:**

- Clear guidance: Users understand why Formulas are the only Homebrew option
- Better UX: Documentation no longer suggests problematic installation methods
- Consistency: Documentation matches the actual distribution infrastructure

## Testing

- Documentation has been reviewed for accuracy
- Installation instructions follow the same format and structure as existing content
- All references to Casks have been removed

**Manual Testing Required:**

- Verify that the documentation renders correctly on the website
- Confirm that all installation commands are accurate and functional

## Dependencies

- None - this is a documentation-only change
- Relies on Homebrew Formula support in the `sentrie-sh/homebrew-tap` repository
