### PR TITLE
Add a **Policy metadata** reference page and align documentation with policy body ordering. Closes #22

### DIFF
--- a/.cursor/rules/copyright-year-on-touch.mdc
+++ b/.cursor/rules/copyright-year-on-touch.mdc
@@ -1,0 +1,25 @@
+---
+description: When editing a licensed source file, refresh the SPDX/Apache Copyright year to the current calendar year; no drive-by updates on untouched files
+alwaysApply: true
+---
+
+# Copyright year when touching licensed sources
+
+When you **modify** a source file in this repository that carries the project’s standard license header (Apache-2.0 / SPDX-style block with a `Copyright <year>` line), **update that year to the current calendar year** in the same edit.
+
+## Which year to use
+
+- Prefer the **actual current year** for the session: use **`Today's date`** from the user or workspace context when it is provided (authoritative for the run).
+- If no date is available, use a **reasonable default** for “now” (do **not** assume a fixed past year such as 2025).
+
+## Scope of updates
+
+- **Only** change the copyright year on files you are **already editing** as part of the task. Do **not** run drive-by or mass copyright-year updates on files you did not touch, unless the user **explicitly** asks for that.
+
+## Files without a header
+
+- If a file has **no** license header but **AGENTS.md** (or other project convention) says licensed sources must have one, add or complete the header per that convention and set **`Copyright <current year>`** (same year rules as above).
+
+## Typical header shape
+
+Refresh the year in the existing `Copyright` line inside the standard comment block (SPDX `License-Identifier`, etc.); keep the rest of the header unchanged unless the edit requires it.

--- a/.cursor/rules/copyright-year-on-touch.mdc
+++ b/.cursor/rules/copyright-year-on-touch.mdc
@@ -1,25 +1,43 @@
 ---
-description: When editing a licensed source file, refresh the SPDX/Apache Copyright year to the current calendar year; no drive-by updates on untouched files
+description: New licensed files use SPDX-FileCopyrightText (© + year + git user.name / optional user.email) and SPDX-License-Identifier; do not change existing headers on ordinary edits.
 alwaysApply: true
 ---
 
-# Copyright year when touching licensed sources
+# SPDX file headers and copyright year
 
-When you **modify** a source file in this repository that carries the project’s standard license header (Apache-2.0 / SPDX-style block with a `Copyright <year>` line), **update that year to the current calendar year** in the same edit.
+## New files and first-time headers
 
-## Which year to use
+When you **create** a new source file that must carry a license header, use this **two-line SPDX shape** (with the file’s normal comment syntax), in order:
+
+```text
+SPDX-FileCopyrightText: © 2026 Binaek Sarkar <binaek89@gmail.com>
+SPDX-License-Identifier: Apache-2.0
+```
+
+Use the **current calendar year** after `©` (the line above shows **2026** as an illustration—replace it with the real current year when it differs). **`SPDX-License-Identifier`** must stay **`Apache-2.0`** for this repository.
+
+Example in a `//` comment language:
+
+```typescript
+// SPDX-FileCopyrightText: © 2026 Binaek Sarkar <binaek89@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+```
+
+**Holder and email:** Prefer the values from **`git config user.name`** and **`git config user.email`** (local/repo override if set, else global). The example above matches this repository’s typical Git identity; if yours differs, substitute accordingly. If **`user.email`** is unset, omit the space and bracketed email after the name.
+
+If Git identity is **not** available or the repo standard differs (e.g. corporate copyright line), use the **copyright holder** style in **sibling source files** in this repository instead.
+
+## Which year is “current”
 
 - Prefer the **actual current year** for the session: use **`Today's date`** from the user or workspace context when it is provided (authoritative for the run).
 - If no date is available, use a **reasonable default** for “now” (do **not** assume a fixed past year such as 2025).
 
-## Scope of updates
+## Existing files
 
-- **Only** change the copyright year on files you are **already editing** as part of the task. Do **not** run drive-by or mass copyright-year updates on files you did not touch, unless the user **explicitly** asks for that.
+When you **modify** a file that **already** has a license header (including **`SPDX-FileCopyrightText`**, legacy **`Copyright …`** lines, or the full Apache boilerplate block), **leave the copyright year and header text unchanged** unless the user **explicitly** asks to refresh, migrate, or correct it.
 
-## Files without a header
+Do **not** run drive-by or mass copyright-year updates on files you did not touch, unless the user **explicitly** asks for that.
 
-- If a file has **no** license header but **AGENTS.md** (or other project convention) says licensed sources must have one, add or complete the header per that convention and set **`Copyright <current year>`** (same year rules as above).
+## Legacy headers
 
-## Typical header shape
-
-Refresh the year in the existing `Copyright` line inside the standard comment block (SPDX `License-Identifier`, etc.); keep the rest of the header unchanged unless the edit requires it.
+Older files may use only `SPDX-License-Identifier` plus a `Copyright …` paragraph and Apache license text. **Do not rewrite those to the two-line form** as part of unrelated edits; only new files (or explicit migration tasks) should use the **`SPDX-FileCopyrightText`** + **`SPDX-License-Identifier`** pattern above.

--- a/.cursor/rules/plan-source-paths.mdc
+++ b/.cursor/rules/plan-source-paths.mdc
@@ -1,0 +1,15 @@
+---
+description: Plan files must link to source using paths relative to the repository root
+alwaysApply: true
+---
+
+# Cursor plans: repository-relative source links
+
+When **writing or generating** Cursor plan markdown (for example under `.cursor/plans/`), reference source files in a way that is valid for anyone who clones the repo.
+
+- Use paths **relative to that plan’s repository root** (the directory that contains `.git` for that project). Examples: `src/app/page.tsx`, `content/docs/foo.md`.
+- **Do not** use machine-local absolute paths in links or prose (no `/Users/...`, `/home/...`, `C:\...`, or workspace-specific prefixes that include a username or machine path).
+- For **markdown links** to files, use repo-root-relative targets, for example `[page.tsx](src/app/page.tsx)`.
+- When the plan spans multiple repositories in a multi-root workspace, make it explicit which repo each path is relative to (e.g. a short label or section per repo) and still avoid absolute paths.
+
+This applies to plan bodies, todos, and any embedded file lists—not only when editing an existing plan file.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
-When you make any changes, update the `PR_DESCRIPTION.md` file to describe the changes you made. The content of the file should be in markdown format. The file should be named `PR_DESCRIPTION.md` and should be placed in the root of the project. If you find existing content in the file that contradicts the changes you have made, overwrite the existing content. The file will be used to generate the pull request description.
+Use AGENTS.md in the `sentrie-sh/sentrie` repository for guidance and guidance only.
 
-The title in the `PR_DESCRIPTION.md` file should be such that it completes the sentence: "If merged, this pull request will ...". Keep it below 60 words. You may use markdown formatting.
+Generate separate per-repo PR description files. 
 
-Make sure that all sources files have the correct license headers.
+Scope commits to the local repository. Prefer small(ish), focused commits here too—one logical change per commit when practical; combine only when inseparable (same fix, feature slice, or mechanical rename). For full commit rules (including message style), follow **Code commits** and **Commit messages** in that `AGENTS.md`.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -126,6 +126,10 @@ export default defineConfig({
               slug: "reference/policies",
             },
             {
+              label: "Policy metadata",
+              slug: "reference/policy-metadata",
+            },
+            {
               label: "Facts",
               slug: "reference/facts",
             },

--- a/src/content/docs/getting-started/writing-your-first-policy.md
+++ b/src/content/docs/getting-started/writing-your-first-policy.md
@@ -3,7 +3,7 @@ title: Writing your first Policy
 description: Learn how to write your first Sentrie policy
 ---
 
-This guide will walk you through creating your first Sentrie policy step by step.
+This guide will walk you through creating your first Sentrie policy step by step. For full syntax, validation, and how multiple **`tag`** lines are indexed, see the [Policy metadata](/reference/policy-metadata/) reference.
 
 ## Basic Policy Structure
 
@@ -12,18 +12,19 @@ A Sentrie policy file consists of exactly one namespace and at least one policy:
 - **Namespace**: A container for related policies.
 - **Policy**: A named collection of rules.
 
-A policy consists of:
+A policy consists of (in this order; see [Policy metadata](/reference/policy-metadata/) and [Policies](/reference/policies/)):
 
+- **Metadata** (optional): `title`, `description`, `version`, and one or more `tag` string literals for humans and tooling—they do not affect evaluation.
+- **Facts**: Input data for the policy (before any `use` if you import modules).
 - **Rules**: Individual decision logic.
-- **Facts**: Input data for the policy.
 - **Exports**: Rules that are exported to make them available for external evaluation.
 
 ## Create a Policy Pack
 
 ```sh
 mkdir my-first-policy-pack
-cd example-policy-pack
-sentrie init example-policy-pack
+cd my-first-policy-pack
+sentrie init my-first-policy-pack
 ```
 
 ## Define a Namespace
@@ -69,6 +70,32 @@ policy user_access {
 
 ```
 
+## Optional policy metadata
+
+You can document the policy for registries, search, and teammates with **metadata** lines at the **top** of the policy body (still inside `policy { ... }`). Values are plain string literals only; they are **not** used when rules run. You can repeat **`tag`** with different keys. See [Policy metadata](/reference/policy-metadata/) for ordering with `fact`, `use`, and the rest of the body.
+
+```diff lang=sentrie
+// first-policy.sentrie
+namespace com/example/user_management
+
+shape User {
+  role: string
+  status: string
+}
+
+policy user_access {
+-  -- policy content goes here
++  title "User access"
++  description "Admin and active-user access for the user management example."
++  version "1.0.0"
++  tag "domain" = "user_management"
++  tag "tier" = "example"
++
++  -- facts and rules go below
+}
+```
+
+
 ## Add Facts
 
 :::note
@@ -86,6 +113,12 @@ shape User {
 }
 
 policy user_access {
+  title "User access"
+  description "Admin and active-user access for the user management example."
+  version "1.0.0"
+  tag "domain" = "user_management"
+  tag "tier" = "example"
+
 +  fact user: User as currentUser
 +  fact context?: Context as ctx default {"environment": "production"}
 }
@@ -112,6 +145,12 @@ shape User {
 }
 
 policy user_access {
+  title "User access"
+  description "Admin and active-user access for the user management example."
+  version "1.0.0"
+  tag "domain" = "user_management"
+  tag "tier" = "example"
+
   fact user: User as currentUser
   fact context?: Context as ctx default {"environment": "production"}
 
@@ -133,7 +172,14 @@ shape User {
 }
 
 policy user_access {
+  title "User access"
+  description "Admin and active-user access for the user management example."
+  version "1.0.0"
+  tag "domain" = "user_management"
+  tag "tier" = "example"
+
   fact user: User as currentUser
+  fact context?: Context as ctx default {"environment": "production"}
 
   rule allow_admin = {
     yield user.role == "admin"
@@ -159,7 +205,14 @@ shape User {
 }
 
 policy user_access {
+  title "User access"
+  description "Admin and active-user access for the user management example."
+  version "1.0.0"
+  tag "domain" = "user_management"
+  tag "tier" = "example"
+
   fact user: User as currentUser
+  fact context?: Context as ctx default {"environment": "production"}
 
   rule allow_admin = {
     yield user.role == "admin"
@@ -188,7 +241,14 @@ shape User {
 }
 
 policy user_access {
+  title "User access"
+  description "Admin and active-user access for the user management example."
+  version "1.0.0"
+  tag "domain" = "user_management"
+  tag "tier" = "example"
+
   fact user: User as currentUser
+  fact context?: Context as ctx default {"environment": "production"}
 
   rule allow_admin = {
     yield user.role == "admin"
@@ -221,8 +281,14 @@ shape User {
 }
 
 policy user_access {
+  title "User access"
+  description "Admin and active-user access for the user management example."
+  version "1.0.0"
+  tag "domain" = "user_management"
+  tag "tier" = "example"
 
   fact user: User as currentUser
+  fact context?: Context as ctx default {"environment": "production"}
 
   rule allow_admin = {
     yield user.role == "admin"

--- a/src/content/docs/reference/facts.md
+++ b/src/content/docs/reference/facts.md
@@ -44,6 +44,8 @@ fact context?: Context as context default { "key": "value" }
 - **Use `?` to mark facts as optional** - Optional facts can be omitted, but if provided, they must be non-null
 - **Facts are always non-nullable** - Null values are not allowed for facts
 - **Required facts cannot have default values** - Only optional facts can have defaults
+- **Facts before uses:** If a policy has both `fact` and `use` statements, every `fact` must appear before the first `use`. A policy may have **uses with no facts** (skip the facts block).
+
 :::
 
 ## Fact Types and Constraints

--- a/src/content/docs/reference/facts.md
+++ b/src/content/docs/reference/facts.md
@@ -6,7 +6,7 @@ description: Facts are input data declarations that provide external values to p
 Facts are named input values that can be injected into policy evaluation. They serve as the primary mechanism for providing external data to policies, enabling them to make decisions based on runtime information.
 
 :::note[Note]
-If a policy uses facts, then they must be declared at the top of the policy. Facts declarations can only be preceded by other facts or comments.
+Facts live in the **facts** section of a policy: after optional [metadata](/reference/policy-metadata/) and before any `use`. Comments may appear anywhere. See [Policies](/reference/policies/) for full ordering.
 :::
 
 ## Fact Declaration

--- a/src/content/docs/reference/functions.md
+++ b/src/content/docs/reference/functions.md
@@ -29,10 +29,10 @@ Functions imported from TypeScript modules are called using the module alias fol
 namespace com/example/auth
 
 policy mypolicy {
+  fact data: string
+
   use { sha256, now } from @sentrie/hash as hash
   use { parse } from @sentrie/json as json
-
-  fact data: string
 
   rule processData = default false {
     let hashValue = hash.sha256(data)
@@ -75,12 +75,12 @@ Sentrie provides comprehensive built-in TypeScript modules under the `@sentrie/*
 namespace com/example/crypto
 
 policy security {
+  fact password: string
+  fact timestamp: number
+
   use { sha256, md5 } from @sentrie/hash
   use { now, parse } from @sentrie/time as time
   use { isValid } from @sentrie/json as json
-
-  fact password: string
-  fact timestamp: number
 
   rule validatePassword = default false {
     let hash = sha256(password)
@@ -100,9 +100,9 @@ You can also import functions from your own TypeScript files:
 namespace com/example/utils
 
 policy processing {
-  use { calculateAge, validateEmail } from "./utils.ts" as utils
-
   fact user: User
+
+  use { calculateAge, validateEmail } from "./utils.ts" as utils
 
   rule validateUser = default false {
     yield utils.calculateAge(user.birthDate) >= 18
@@ -156,10 +156,10 @@ let result = expensiveFunction(data)!3600  -- Cached for 1 hour
 namespace com/example/processing
 
 policy dataProcessing {
+  fact data: string
+
   use { sha256 } from @sentrie/hash
   use { complexCalculation } from "./heavy-compute.ts" as compute
-
-  fact data: string
 
   rule processData = default false {
     -- Memoize expensive computation for 10 minutes
@@ -196,11 +196,11 @@ Functions can be used anywhere expressions are allowed, including in `let` decla
 namespace com/example/complex
 
 policy example {
-  use { sha256 } from @sentrie/hash
-  use { now } from @sentrie/time as time
-
   fact userData: map[string]any
   fact items: list[string]
+
+  use { sha256 } from @sentrie/hash
+  use { now } from @sentrie/time as time
 
   -- Policy-level let with function calls
   let itemCount = count(items)

--- a/src/content/docs/reference/index.md
+++ b/src/content/docs/reference/index.md
@@ -81,7 +81,7 @@ A namespace can contain:
 
 ## Policies
 
-Policies are containers for rules, facts, and other declarations.
+Policies are containers for rules, facts, and other declarations. See [Policy metadata](/reference/policy-metadata/) for `title`, `description`, `version`, and `tag`, and for the required **metadata → facts → uses → body** ordering.
 
 ### Syntax
 
@@ -93,13 +93,14 @@ policy IDENT {
 
 ### Policy Statements
 
-A policy can contain:
+A policy can contain (in grouped order; comments anywhere):
 
-- **Rules**: `rule IDENT = ...`
+- **Metadata** (optional): `title`, `description`, `version`, `tag "key" = "value"`
 - **Facts**: `fact IDENT ('?'?) : primitive/shape ('as' IDENT)? ('default' expr)?`
-- **Shapes**: `shape IDENT { ... }`
-- **Variables**: `let IDENT : primitive/shape = expr`
 - **Use statements**: `use { function1, function2 } from source as alias`
+- **Rules**: `rule IDENT = ...`
+- **Shapes**: `shape IDENT { ... }` (policy-local; body section)
+- **Variables**: `let IDENT : primitive/shape = expr`
 - **Exports**: `export decision of IDENT`
 - **Comments**: `-- comment`
 
@@ -488,11 +489,11 @@ Built-in modules are prefixed with `@sentrie/`:
 namespace com/example/auth
 
 policy mypolicy {
+  fact data!: string
+
   use { now } from @sentrie/time as time
   use { sha256 } from @sentrie/hash
   use { parse, format } from @sentrie/json as json
-
-  fact data!: string
 
   rule processData = default false {
     let timestamp = time.now()
@@ -513,9 +514,9 @@ You can import TypeScript files from your policy pack using relative paths:
 namespace com/example/auth
 
 policy mypolicy {
-  use { calculateAge, validateEmail } from "./utils.ts" as utils
-
   fact user!: User
+
+  use { calculateAge, validateEmail } from "./utils.ts" as utils
 
   rule validateUser = default false {
     yield utils.calculateAge(user.birthDate) >= 18

--- a/src/content/docs/reference/let.md
+++ b/src/content/docs/reference/let.md
@@ -342,10 +342,10 @@ rule complexCalculation = default 0 {
 namespace com/example/utils
 
 policy processing {
+  fact data: string as inputData
+
   use { sha256, now } from @sentrie/hash as hash
   use { parse } from @sentrie/json as json
-
-  fact data: string as inputData
 
   rule processData = default false {
     let timestamp = hash.now()

--- a/src/content/docs/reference/policies.md
+++ b/src/content/docs/reference/policies.md
@@ -24,6 +24,19 @@ Statements inside a policy follow a **fixed grouped order** (comments may appear
 - **Rules**: Decision logic with conditions and outcomes with `rule` statements
 - **Exports**: Rule outcomes for external consumption with `export` statements
 
+## Policy body ordering (required)
+
+Ignoring comments, statements inside a policy must follow this **grouped** order:
+
+1. **Metadata block** (optional): any of `title`, `description`, `version`, `tag*`, grouped together at the top.
+2. **Facts block** (optional): `fact*` — all facts before any `use`.
+3. **Uses block** (optional): `use*`.
+4. **Body**: `rule`, `export` (rule export), `let`, `shape`, etc.
+
+**Comments** may appear anywhere and do **not** break these groups. **Metadata** may be separated only by comments and still count as one contiguous metadata block.
+
+**Shapes** in a policy are **body** statements. Putting `shape` (or any body statement) before the header sections is invalid if you still need `fact` / `use` / metadata after it.
+
 ## Declaring Policies
 
 ### Basic Syntax

--- a/src/content/docs/reference/policies.md
+++ b/src/content/docs/reference/policies.md
@@ -15,10 +15,13 @@ Policies are the fundamental building blocks of Sentrie policy packs. They encap
 
 ### Core Components
 
-- **Facts**: Declare input data declarations with types and defaults with `fact` statements
+Statements inside a policy follow a **fixed grouped order** (comments may appear anywhere): optional **metadata** → optional **facts** → optional **uses** → **body** (`let`, `rule`, `export`, policy-local `shape`, …). See [Policy metadata](/reference/policy-metadata/) for `title`, `description`, `version`, and `tag`.
+
+- **Metadata** (optional): `title`, `description`, `version`, `tag` — static strings for docs and tooling
+- **Facts**: Input data with `fact` statements (**all facts before any `use`**)
+- **Use**: External TypeScript functions via `use` statements (after facts, if any)
 - **Variables**: Intermediate calculations using `let` statements
 - **Rules**: Decision logic with conditions and outcomes with `rule` statements
-- **Use**: External TypeScript functions via `use` statements
 - **Exports**: Rule outcomes for external consumption with `export` statements
 
 ## Declaring Policies
@@ -52,11 +55,17 @@ shape Resource {
 }
 
 policy userAccess {
-  use { verifySignature, isBusinessHours } from "./auth-utils.ts" as auth
+  title "User access control"
+  description "Read/write access for documents based on ownership and auth signals"
+  version "1.0.0"
+  tag "domain" = "authz"
+  tag "cloud" = "aws"
 
   fact user: User as currentUser
   fact resource: Resource as currentResource
   fact context?: Context as ctx default { "environment": "production" }
+
+  use { verifySignature, isBusinessHours } from "./auth-utils.ts" as auth
 
   let isResourceOwner = user.id == resource.owner
   let hasValidSignature = auth.verifySignature(user.id, resource.id)

--- a/src/content/docs/reference/policy-metadata.md
+++ b/src/content/docs/reference/policy-metadata.md
@@ -1,0 +1,80 @@
+---
+title: Policy metadata
+description: Static metadata inside policy blocks—title, description, version, and tags—for humans and tooling; no effect on evaluation.
+---
+
+Policy metadata is **optional** information you attach inside a `policy { ... }` block. It is intended for documentation, registries, search, and UIs. Metadata values are **plain string literals only**—no expressions, interpolation, or computed values.
+
+Metadata does **not** participate in evaluation and does not change rule outcomes.
+
+## Syntax
+
+All of the following appear **only** inside a policy body (not at namespace or file top level).
+
+```sentrie
+title "Short human-readable name"
+description "Longer explanation; may be empty \"\""
+version "1.2.3"
+tag "key" = "value"
+```
+
+- **`title`**: one string; after trimming whitespace it must be non-empty.
+- **`description`**: one string; may be empty after trim.
+- **`version`**: one string that must be a valid **SemVer** (as accepted by Sentrie’s semver parser, including a leading `v` such as `"v1.2.3"` if supported). The **source literal** is preserved for display.
+- **`tag`**: `tag "key" = "value"`; repeatable. The **key** must be non-empty after trim. The **value** may be empty or whitespace-only; duplicate keys are allowed (tags are multi-valued, order preserved).
+
+`title`, `description`, `version`, and `tag` are **reserved keywords** in the lexer everywhere in a program, not only inside policies.
+
+## Policy body ordering (required)
+
+Ignoring comments, statements inside a policy must follow this **grouped** order:
+
+1. **Metadata block** (optional): any of `title`, `description`, `version`, `tag*`, grouped together at the top.
+2. **Facts block** (optional): `fact*` — all facts before any `use`.
+3. **Uses block** (optional): `use*`.
+4. **Body**: `rule`, `export` (rule export), `let`, `shape`, etc.
+
+**Comments** may appear anywhere and do **not** break these groups. **Metadata** may be separated only by comments and still count as one contiguous metadata block.
+
+**Facts before uses:** If a policy has both `fact` and `use` statements, every `fact` must appear before the first `use`. A policy may have **uses with no facts** (skip the facts block).
+
+**Shapes** in a policy are **body** statements. Putting `shape` (or any body statement) before the header sections is invalid if you still need `fact` / `use` / metadata after it.
+
+## Uniqueness
+
+- At most one `title`, one `description`, and one `version` per policy.
+- `tag` may repeat; the same key may appear multiple times.
+
+## Index representation (tooling)
+
+When a policy is indexed, tags are kept in **source order** as a list of pairs. Implementations may also expose a **map from key to values** (all values for that key, in order) for lookups. If a map is provided, **iteration order over the map is not a stability contract**—use the ordered list when you need deterministic output.
+
+## Validation errors (indexing)
+
+When indexing reports an error, messages include the source location. Typical cases:
+
+| Situation | Message (core text) |
+|-----------|---------------------|
+| Metadata after facts or uses (but before body) | `title, description, version, and tag may only appear in one contiguous block at the top of the policy, before all fact and use statements.` |
+| `fact` after a `use` | `fact statements must appear before any use statements.` |
+| `fact`, `use`, or metadata after body has started | `'<keyword>' must appear before rules, exports, lets, and shapes.` |
+| Duplicate `title` / `description` / `version` | `conflict: policy …` (with both locations) |
+| Empty / whitespace-only `title` | `policy title must not be empty or whitespace-only.` |
+| Empty / whitespace-only tag key | `tag key must not be empty or whitespace-only.` |
+| Invalid `version` string | `Invalid policy version: expected SemVer string (e.g., "1.2.3").` |
+
+Exact wording may evolve slightly; rely on the stable phrases above when writing tests or tooling.
+
+## Conventional tag keys (optional)
+
+The language does **not** restrict tag keys. For interoperability, common conventional keys include: `category`, `domain`, `framework`, `cloud`, `service`, `owner`, `severity`, `status` (e.g. draft/stable/deprecated). These are conventions only—not enforced by the parser.
+
+## Non-goals
+
+- No metadata at namespace or global scope in this feature.
+- No effect on evaluation or rule semantics.
+
+## See also
+
+- [Policies](/reference/policies/) — overall policy structure and examples
+- [Issue #61](https://github.com/sentrie-sh/sentrie/issues/61) — original design discussion

--- a/src/content/docs/reference/policy-metadata.md
+++ b/src/content/docs/reference/policy-metadata.md
@@ -20,7 +20,7 @@ tag "key" = "value"
 
 - **`title`**: one string; after trimming whitespace it must be non-empty.
 - **`description`**: one string; may be empty after trim.
-- **`version`**: one string that must be a valid **SemVer** (as accepted by Sentrie’s semver parser, including a leading `v` such as `"v1.2.3"` if supported). The **source literal** is preserved for display.
+- **`version`**: one string. **SemVer validation** runs on the literal after **trimming leading and trailing whitespace** (so `"  v1.2.3  "` is accepted as `1.2.3`). **`VersionLiteral` / stored display text** keeps the **exact source string** from the policy, including any surrounding spaces inside the quotes.
 - **`tag`**: `tag "key" = "value"`; repeatable. The **key** must be non-empty after trim. The **value** may be empty or whitespace-only; duplicate keys are allowed (tags are multi-valued, order preserved).
 
 `title`, `description`, `version`, and `tag` are **reserved keywords** in the lexer everywhere in a program, not only inside policies.

--- a/src/content/docs/reference/policy-metadata.md
+++ b/src/content/docs/reference/policy-metadata.md
@@ -25,29 +25,10 @@ tag "key" = "value"
 
 `title`, `description`, `version`, and `tag` are **reserved keywords** in the lexer everywhere in a program, not only inside policies.
 
-## Policy body ordering (required)
-
-Ignoring comments, statements inside a policy must follow this **grouped** order:
-
-1. **Metadata block** (optional): any of `title`, `description`, `version`, `tag*`, grouped together at the top.
-2. **Facts block** (optional): `fact*` — all facts before any `use`.
-3. **Uses block** (optional): `use*`.
-4. **Body**: `rule`, `export` (rule export), `let`, `shape`, etc.
-
-**Comments** may appear anywhere and do **not** break these groups. **Metadata** may be separated only by comments and still count as one contiguous metadata block.
-
-**Facts before uses:** If a policy has both `fact` and `use` statements, every `fact` must appear before the first `use`. A policy may have **uses with no facts** (skip the facts block).
-
-**Shapes** in a policy are **body** statements. Putting `shape` (or any body statement) before the header sections is invalid if you still need `fact` / `use` / metadata after it.
-
 ## Uniqueness
 
 - At most one `title`, one `description`, and one `version` per policy.
 - `tag` may repeat; the same key may appear multiple times.
-
-## Index representation (tooling)
-
-When a policy is indexed, tags are kept in **source order** as a list of pairs. Implementations may also expose a **map from key to values** (all values for that key, in order) for lookups. If a map is provided, **iteration order over the map is not a stability contract**—use the ordered list when you need deterministic output.
 
 ## Validation errors (indexing)
 

--- a/src/content/docs/reference/typescript_modules/index.md
+++ b/src/content/docs/reference/typescript_modules/index.md
@@ -13,13 +13,13 @@ Import and use built-in modules in your policies:
 namespace com/example/mypolicy
 
 policy mypolicy {
+  fact data!: string
+  fact timestamp!: number
+
   use { now } from @sentrie/time
   use { sha256 } from @sentrie/hash
   use { parse } from @sentrie/js as json
   use { isValid } from @sentrie/json as jsonUtil
-
-  fact data!: string
-  fact timestamp!: number
 
   rule processData = default false {
     let hash = sha256(data)
@@ -221,14 +221,14 @@ Functions for generating UUIDs (Universally Unique Identifiers).
 namespace com/example/auth
 
 policy authentication {
-  use { sha256, hmac } from @sentrie/hash
-  use { decode, verify } from @sentrie/jwt
-  use { base64Decode } from @sentrie/encoding
-
   fact token!: string
   fact secretKey!: string
   fact passwordInput!: string
   fact expectedHash!: string
+
+  use { sha256, hmac } from @sentrie/hash
+  use { decode, verify } from @sentrie/jwt
+  use { base64Decode } from @sentrie/encoding
 
   rule verifyToken = default false {
     let isValid = jwt.verify(token, secretKey)
@@ -251,12 +251,12 @@ policy authentication {
 namespace com/example/validation
 
 policy validation {
+  fact email!: string
+  fact jsonData!: string
+
   use { match } from @sentrie/regex
   use { length } from @sentrie/js as str
   use { isValid } from @sentrie/json as jsonUtil
-
-  fact email!: string
-  fact jsonData!: string
 
   rule validateEmail = default false {
     let emailPattern = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"
@@ -279,12 +279,12 @@ policy validation {
 namespace com/example/network
 
 policy network {
-  use { cidrContains, isPrivate, parseIP } from @sentrie/net
-  use { getHost, isValid } from @sentrie/url
-
   fact clientIp!: string
   fact allowedCidr!: string
   fact requestUrl!: string
+
+  use { cidrContains, isPrivate, parseIP } from @sentrie/net
+  use { getHost, isValid } from @sentrie/url
 
   rule checkAccess = default false {
     let ip = net.parseIP(clientIp)
@@ -310,10 +310,10 @@ policy network {
 namespace com/example/time
 
 policy time {
-  use { now, isBefore, addDuration, format } from @sentrie/time
-
   fact tokenExpiry!: number
   fact sessionStart!: number
+
+  use { now, isBefore, addDuration, format } from @sentrie/time
 
   rule checkTokenExpiry = default false {
     let currentTime = time.now()

--- a/src/content/docs/reference/typescript_modules/sentrie/collection.md
+++ b/src/content/docs/reference/typescript_modules/sentrie/collection.md
@@ -317,9 +317,10 @@ let merged = collection.map_merge(user1, user2)  // {"name": "John", "age": 31, 
 namespace com/example/mypolicy
 
 policy mypolicy {
-  use { list_includes, list_sort, map_keys, map_get } from @sentrie/collection
   fact numbers!: list[number]
   fact user!: document
+
+  use { list_includes, list_sort, map_keys, map_get } from @sentrie/collection
 
   rule myrule = default false {
     let sorted = collection.list_sort(numbers)

--- a/src/content/docs/reference/typescript_modules/sentrie/crypto.md
+++ b/src/content/docs/reference/typescript_modules/sentrie/crypto.md
@@ -31,10 +31,10 @@ Computes the SHA-256 hash of a string. This function uses a streaming hash imple
 namespace com/example/auth
 
 policy mypolicy {
-  use { sha256 } from @sentrie/crypto
-
   fact passwordInput!: string
   fact expectedHash!: string
+
+  use { sha256 } from @sentrie/crypto
 
   rule verifyPassword = default false {
     let hash = sha256(passwordInput)

--- a/src/content/docs/reference/typescript_modules/sentrie/encoding.md
+++ b/src/content/docs/reference/typescript_modules/sentrie/encoding.md
@@ -164,8 +164,9 @@ let decoded = encoding.urlDecode("Hello%2C%20World%21")  // "Hello, World!"
 namespace com/example/mypolicy
 
 policy mypolicy {
-  use { base64Encode, base64Decode, urlEncode, urlDecode } from @sentrie/encoding
   fact data!: string
+
+  use { base64Encode, base64Decode, urlEncode, urlDecode } from @sentrie/encoding
 
   rule encodeData = default false {
     let encoded = encoding.base64Encode(data)

--- a/src/content/docs/reference/typescript_modules/sentrie/hash.md
+++ b/src/content/docs/reference/typescript_modules/sentrie/hash.md
@@ -114,12 +114,13 @@ let mac = hash.hmac("sha256", "Hello, World!", "secret-key")
 namespace com/example/auth
 
 policy mypolicy {
-  use { sha256, hmac } from @sentrie/hash
   fact passwordInput!: string
   fact expectedHash!: string
   fact secretKey!: string
   fact message!: string
   fact expectedMac!: string
+
+  use { sha256, hmac } from @sentrie/hash
 
   rule verifyPassword = default false {
     let hash = hash.sha256(passwordInput)

--- a/src/content/docs/reference/typescript_modules/sentrie/json.md
+++ b/src/content/docs/reference/typescript_modules/sentrie/json.md
@@ -54,10 +54,10 @@ See the [@sentrie/js](/reference/typescript_modules/sentrie/js) documentation fo
 namespace com/example/mypolicy
 
 policy mypolicy {
+  fact data!: string
+
   use { isValid } from @sentrie/json as jsonUtil
   use { parse, stringify } from @sentrie/js as json
-
-  fact data!: string
 
   rule processData = default false {
     let isValid = jsonUtil.isValid(data)

--- a/src/content/docs/reference/typescript_modules/sentrie/jwt.md
+++ b/src/content/docs/reference/typescript_modules/sentrie/jwt.md
@@ -104,9 +104,10 @@ let header = jwt.getHeader(token)
 namespace com/example/auth
 
 policy mypolicy {
-  use { decode, verify } from @sentrie/jwt
   fact token!: string
   fact secretKey!: string
+
+  use { decode, verify } from @sentrie/jwt
 
   rule verifyToken = default false {
     let isValid = jwt.verify(token, secretKey)

--- a/src/content/docs/reference/typescript_modules/sentrie/net.md
+++ b/src/content/docs/reference/typescript_modules/sentrie/net.md
@@ -243,9 +243,10 @@ let isMulti = net.isMulticast("224.0.0.1")  // true
 namespace com/example/network
 
 policy mypolicy {
-  use { cidrContains, parseIP, isPrivate, isPublic } from @sentrie/net
   fact clientIp!: string
   fact allowedCidr!: string
+
+  use { cidrContains, parseIP, isPrivate, isPublic } from @sentrie/net
 
   rule checkAccess = default false {
     let ip = net.parseIP(clientIp)

--- a/src/content/docs/reference/typescript_modules/sentrie/regex.md
+++ b/src/content/docs/reference/typescript_modules/sentrie/regex.md
@@ -143,9 +143,10 @@ let parts = regex.split("\\s+", "hello   world  test")  // ["hello", "world", "t
 namespace com/example/validation
 
 policy mypolicy {
-  use { match, find, replaceAll } from @sentrie/regex
   fact email!: string
   fact phoneNumber!: string
+
+  use { match, find, replaceAll } from @sentrie/regex
 
   rule validateEmail = default false {
     let emailPattern = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"

--- a/src/content/docs/reference/typescript_modules/sentrie/semver.md
+++ b/src/content/docs/reference/typescript_modules/sentrie/semver.md
@@ -198,10 +198,11 @@ let noMeta = semver.metadata("1.2.3")  // null
 namespace com/example/version
 
 policy mypolicy {
-  use { compare, satisfies, major, minor, patch } from @sentrie/semver
   fact currentVersion!: string
   fact requiredVersion!: string
   fact versionConstraint!: string
+
+  use { compare, satisfies, major, minor, patch } from @sentrie/semver
 
   rule checkVersion = default false {
     let comparison = semver.compare(currentVersion, requiredVersion)

--- a/src/content/docs/reference/typescript_modules/sentrie/time.md
+++ b/src/content/docs/reference/typescript_modules/sentrie/time.md
@@ -211,8 +211,9 @@ Examples:
 namespace com/example/access
 
 policy mypolicy {
-  use { now, isBefore, addDuration, format } from @sentrie/time
   fact tokenExpiry!: number
+
+  use { now, isBefore, addDuration, format } from @sentrie/time
 
   rule checkTokenExpiry = default false {
     let currentTime = time.now()

--- a/src/content/docs/reference/typescript_modules/sentrie/url.md
+++ b/src/content/docs/reference/typescript_modules/sentrie/url.md
@@ -157,8 +157,9 @@ let invalid = url.isValid("not-a-url")  // false
 namespace com/example/validation
 
 policy mypolicy {
-  use { parse, getHost, getPath, isValid } from @sentrie/url
   fact requestUrl!: string
+
+  use { parse, getHost, getPath, isValid } from @sentrie/url
 
   rule validateUrl = default false {
     let isValid = url.isValid(requestUrl)

--- a/src/content/docs/reference/typescript_modules/sentrie/uuid.md
+++ b/src/content/docs/reference/typescript_modules/sentrie/uuid.md
@@ -82,8 +82,9 @@ let uuid = uuid.v7()  // Time-ordered UUID with Unix timestamp
 namespace com/example/resources
 
 policy mypolicy {
-  use { v4, v7 } from @sentrie/uuid
   fact resourceType!: string
+
+  use { v4, v7 } from @sentrie/uuid
 
   rule createResource = default false {
     let id = uuid.v4()

--- a/src/content/docs/reference/using-typescript.md
+++ b/src/content/docs/reference/using-typescript.md
@@ -33,12 +33,16 @@ Built-in libraries are prefixed with `@sentrie/`:
 ```text
 namespace com/example/auth
 
-policy mypolicy {
-  use { now } from @sentrie/time
-  use { sha256 } from @sentrie/hash
+shape User {
+  passwordHash: string
+}
 
+policy mypolicy {
   fact user!: User
   fact passwordInput!: string
+
+  use { now } from @sentrie/time
+  use { sha256 } from @sentrie/hash
 
   rule myrule = default false {
     let currentTime = time.now()
@@ -57,11 +61,16 @@ You can import TypeScript files from your policy pack using relative paths. Thes
 ```text
 namespace com/example/auth
 
+shape User {
+  birthDate: string
+  email: string
+}
+
 policy mypolicy {
+  fact user: User
+
   use { calculateAge } from "./utils.ts" as utils
   use { validateEmail } from "../helpers/validation.ts"
-
-  fact user!: utils.User
 
   rule myrule = default false {
     yield utils.calculateAge(user.birthDate) >= 18
@@ -86,13 +95,13 @@ shape User {
 }
 
 policy mypolicy {
-  use { md5, sha256 } from @sentrie/hash
-  use { now } from @sentrie/time
-  use { calculateAge, validateEmail } from "./utils.ts"
-
   fact user!: User
   fact passwordInput!: string
   fact userAge!: number
+
+  use { md5, sha256 } from @sentrie/hash
+  use { now } from @sentrie/time
+  use { calculateAge, validateEmail } from "./utils.ts" as utils
 
   rule myrule = default false {
     yield

--- a/src/content/docs/structure-of-a-policy-pack/program-file.md
+++ b/src/content/docs/structure-of-a-policy-pack/program-file.md
@@ -59,15 +59,12 @@ policy billing {
 
 ### Policy structure
 
-A `policy` statement is a container for related:
+A `policy` statement is a container for related declarations in this **order** (comments allowed between lines):
 
-- facts
-- variables
-- rule declarations
-- decision imports
-- decision exports
-- `use` declarations
-- shape declarations
+- optional **metadata** (`title`, `description`, `version`, `tag`)
+- optional **facts** (all `fact` before any `use`)
+- optional **`use`** imports
+- **body**: `let`, `rule`, `export`, and policy-local `shape` declarations
 
 ```hcl
 namespace com/example/myauth
@@ -77,12 +74,12 @@ shape User {
 }
 
 policy auth {
-  use { calculateAge } from "./utils.ts" as utils
-  use { hash } from @sentrie/crypto -- will alias to crypto by default
-
   fact user: User
   fact passwordInput: string
   fact userAge: number
+
+  use { calculateAge } from "./utils.ts" as utils
+  use { hash } from @sentrie/crypto -- will alias to crypto by default
 
   let isPasswordValid = crypto.md5(passwordInput) == user.passwordHash
   let calculatedUserAge = utils.calculateAge(user.birthDate)

--- a/src/content/docs/structure-of-a-policy-pack/program-file.md
+++ b/src/content/docs/structure-of-a-policy-pack/program-file.md
@@ -59,9 +59,9 @@ policy billing {
 
 ### Policy structure
 
-A `policy` statement is a container for related declarations in this **order** (comments allowed between lines):
+A `policy` statement is a container for related declarations in this **order** (comments allowed between lines). See [Policy metadata](/reference/policy-metadata/) for syntax, validation, and how metadata is indexed.
 
-- optional **metadata** (`title`, `description`, `version`, `tag`)
+- optional **metadata** (`title`, `description`, `version`, repeatable `tag`)
 - optional **facts** (all `fact` before any `use`)
 - optional **`use`** imports
 - **body**: `let`, `rule`, `export`, and policy-local `shape` declarations
@@ -74,6 +74,12 @@ shape User {
 }
 
 policy auth {
+  title "Authentication"
+  description "Password and age checks for sign-in."
+  version "1.0.0"
+  tag "pack" = "myauth"
+  tag "surface" = "sign_in"
+
   fact user: User
   fact passwordInput: string
   fact userAge: number
@@ -96,6 +102,7 @@ policy auth {
 }
 
 ```
+
 
 ## File Organization
 

--- a/src/content/docs/structure-of-a-policy-pack/typescript-file.mdx
+++ b/src/content/docs/structure-of-a-policy-pack/typescript-file.mdx
@@ -52,9 +52,9 @@ Use relative paths from the policy file location:
 namespace com/example/auth
 
 policy userAccess {
-  use { calculateAge, validateEmail } from "./utils.ts" as utils
-
   fact user!: User
+
+  use { calculateAge, validateEmail } from "./utils.ts" as utils
 
   rule checkAccess = {
     yield utils.calculateAge(user.birthDate) >= 18
@@ -79,9 +79,9 @@ Use `@local` prefix for paths relative to the pack root ([sentrie.pack.toml](/st
 namespace com/example/auth
 
 policy userAccess {
-  use { calculateAge } from "@local/utils/helpers" as helpers
-
   fact user!: User
+
+  use { calculateAge } from "@local/utils/helpers" as helpers
 
   rule checkAccess = {
     yield helpers.calculateAge(user.birthDate) >= 18
@@ -292,11 +292,11 @@ shape User {
 }
 
 policy userAccess {
-  // Only functions can be imported via 'use' statement
-  use { calculateAge, verifyPassword, isValidUser } from "./utils/user-helpers.ts" as userUtils
-
   fact user!: User
   fact passwordInput!: string
+
+  // Only functions can be imported via 'use' statement
+  use { calculateAge, verifyPassword, isValidUser } from "./utils/user-helpers.ts" as userUtils
 
   rule allowAccess = {
     yield userUtils.isValidUser(user)


### PR DESCRIPTION
## Summary

- Adds [`src/content/docs/reference/policy-metadata.md`](src/content/docs/reference/policy-metadata.md) covering syntax, phased ordering, validation, global keyword reservation, error categories, optional tag conventions, and how indexed tags appear as ordered pairs vs an optional key→values map (map iteration order not stable).
- Registers the page in [`astro.config.mjs`](astro.config.mjs) under Reference (after Policies).
- Updates [`reference/policies.md`](src/content/docs/reference/policies.md), [`structure-of-a-policy-pack/program-file.md`](src/content/docs/structure-of-a-policy-pack/program-file.md), [`reference/index.md`](src/content/docs/reference/index.md), [`reference/facts.md`](src/content/docs/reference/facts.md), [`reference/let.md`](src/content/docs/reference/let.md), [`reference/using-typescript.md`](src/content/docs/reference/using-typescript.md), [`reference/functions.md`](src/content/docs/reference/functions.md), [`structure-of-a-policy-pack/typescript-file.mdx`](src/content/docs/structure-of-a-policy-pack/typescript-file.mdx), and all [`reference/typescript_modules/`](src/content/docs/reference/typescript_modules/) complete examples so **facts precede `use`** (and metadata first when shown).

## Testing

- Documentation-only; run `yarn build` locally to verify the Starlight site.
