### PR TITLE
Update website docs to reflect the `serve` flag rename from `--port`/`--listen` to `--http-port`/`--http-listen`. Closes #27

### DIFF
--- a/src/content/docs/cli-reference/index.md
+++ b/src/content/docs/cli-reference/index.md
@@ -50,9 +50,9 @@ sentrie serve [OPTIONS]
 
 | Option            | Type     | Default     | Description                       |
 | ----------------- | -------- | ----------- | --------------------------------- |
-| `--port`          | int      | `7529`      | Port to listen on                 |
+| `--http-port`     | int      | `7529`      | Port to listen on                 |
 | `--pack-location` | string   | `./`        | Directory containing policy files |
-| `--listen`        | []string | `["local"]` | Address(es) to listen on          |
+| `--http-listen`   | []string | `["local"]` | Address(es) to listen on          |
 
 #### Examples
 
@@ -61,13 +61,13 @@ sentrie serve [OPTIONS]
 sentrie serve
 
 # Start server on custom port
-sentrie serve --port 8080
+sentrie serve --http-port 8080
 
 # Start server with custom pack location
 sentrie serve --pack-location /path/to/policies
 
 # Start server on specific addresses
-sentrie serve --listen 0.0.0.0 --listen 127.0.0.1
+sentrie serve --http-listen 0.0.0.0 --http-listen 127.0.0.1
 
 # Start server with debug logging
 sentrie serve --debug --log-level DEBUG
@@ -174,6 +174,7 @@ Execute a policy or rule. The `{target...}` path parameter contains the full pat
 - `/decision/{namespace}/{policy}` - Execute all exported rules in a policy
 
 The path is resolved to extract:
+
 - `namespace`: The namespace (all segments except the last two)
 - `policy`: The policy name (second to last segment)
 - `rule`: The rule name (last segment, optional)
@@ -231,6 +232,7 @@ Query parameters are parsed as run configuration (currently parsed but not used 
 Errors are returned using RFC 9457 Problem Details format with `Content-Type: application/problem+json`:
 
 **400 Bad Request**
+
 ```json
 {
   "type": "https://sentrie.sh/problems/400",
@@ -242,6 +244,7 @@ Errors are returned using RFC 9457 Problem Details format with `Content-Type: ap
 ```
 
 **404 Not Found**
+
 ```json
 {
   "type": "https://sentrie.sh/problems/404",
@@ -253,6 +256,7 @@ Errors are returned using RFC 9457 Problem Details format with `Content-Type: ap
 ```
 
 **405 Method Not Allowed**
+
 ```json
 {
   "type": "https://sentrie.sh/problems/405",
@@ -367,7 +371,7 @@ sentrie serve
 ```bash
 # Error: port 7529 is already in use
 # Solution: Use a different port
-sentrie serve --port 8080
+sentrie serve --http-port 8080
 ```
 
 #### Policy Not Found
@@ -472,7 +476,7 @@ sentrie = "0.1.0"
 4. **Start the server**:
 
 ```bash
-sentrie serve --pack-location . --port 8080
+sentrie serve --pack-location . --http-port 8080
 ```
 
 5. **Test the policy**:

--- a/src/content/docs/cli-reference/serve.md
+++ b/src/content/docs/cli-reference/serve.md
@@ -21,24 +21,24 @@ The `serve` command starts an HTTP server that provides a REST API for evaluatin
 
 | Option            | Type     | Default     | Description                       |
 | ----------------- | -------- | ----------- | --------------------------------- |
-| `--port`          | int      | `7529`      | Port to listen on                 |
+| `--http-port`     | int      | `7529`      | Port to listen on                 |
 | `--pack-location` | string   | `./`        | Directory containing policy files |
-| `--listen`        | []string | `["local"]` | Address(es) to listen on          |
+| `--http-listen`   | []string | `["local"]` | Address(es) to listen on          |
 
-### --port
+### --http-port
 
 Specifies the port number for the HTTP server to listen on.
 
 ```bash
-sentrie serve --port 8080
+sentrie serve --http-port 8080
 ```
 
 **Default**: `7529` (PLCY on a phone keypad)
 
 **Examples**:
 
-- `--port 8080` - Listen on port 8080
-- `--port 3000` - Listen on port 3000
+- `--http-port 8080` - Listen on port 8080
+- `--http-port 3000` - Listen on port 3000
 
 ### --pack-location
 
@@ -61,22 +61,22 @@ sentrie serve --pack-location /path/to/policies
 - Directory must contain `.sentrie` policy files
 - Optional `sentrie.pack.toml` file for pack metadata
 
-### --listen
+### --http-listen
 
 Specifies the network addresses to listen on.
 
 ```bash
-sentrie serve --listen 0.0.0.0 --listen 127.0.0.1
+sentrie serve --http-listen 0.0.0.0 --http-listen 127.0.0.1
 ```
 
 **Default**: `["local"]` (localhost only)
 
 **Examples**:
 
-- `--listen local` - Listen on localhost only
-- `--listen 0.0.0.0` - Listen on all interfaces
-- `--listen 127.0.0.1` - Listen on localhost
-- `--listen 192.168.1.100` - Listen on specific IP
+- `--http-listen local` - Listen on localhost only
+- `--http-listen 0.0.0.0` - Listen on all interfaces
+- `--http-listen 127.0.0.1` - Listen on localhost
+- `--http-listen 192.168.1.100` - Listen on specific IP
 
 **Security Note**: Listening on `0.0.0.0` makes the server accessible from any network interface. Use with caution in production environments.
 
@@ -99,7 +99,7 @@ The `serve` command respects these environment variables:
 sentrie serve
 
 # Start server on custom port
-sentrie serve --port 8080
+sentrie serve --http-port 8080
 
 # Start server with custom pack location
 sentrie serve --pack-location ./my-policies
@@ -111,7 +111,7 @@ sentrie serve --pack-location ./my-policies
 # Production setup with environment variables
 export SENTRIE_LOG_LEVEL=WARN
 export SENTRIE_PORT=8080
-sentrie serve --pack-location /etc/sentrie/policies --listen 0.0.0.0
+sentrie serve --pack-location /etc/sentrie/policies --http-listen 0.0.0.0
 ```
 
 ### Development Setup
@@ -125,7 +125,7 @@ sentrie serve --debug --log-level DEBUG --pack-location ./policies
 
 ```bash
 # Listen on multiple addresses
-sentrie serve --listen 127.0.0.1 --listen 192.168.1.100 --port 8080
+sentrie serve --http-listen 127.0.0.1 --http-listen 192.168.1.100 --http-port 8080
 ```
 
 ## Server Behavior
@@ -195,7 +195,7 @@ curl -X POST "http://localhost:7529/decision/com/example/auth/user/allow" \
 ```bash
 # Error: port 7529 is already in use
 # Solution: Use a different port
-sentrie serve --port 8080
+sentrie serve --http-port 8080
 ```
 
 #### Policy Not Found
@@ -379,7 +379,7 @@ sentrie = "0.1.0"
 4. **Start the server**:
 
 ```bash
-sentrie serve --pack-location . --port 8080
+sentrie serve --pack-location . --http-port 8080
 ```
 
 5. **Test the policy**:
@@ -398,8 +398,8 @@ export SENTRIE_LOG_LEVEL=WARN
 export SENTRIE_PORT=8080
 sentrie serve \
   --pack-location /etc/sentrie/policies \
-  --listen 0.0.0.0 \
-  --port 8080
+  --http-listen 0.0.0.0 \
+  --http-port 8080
 ```
 
 ### Development Setup
@@ -410,5 +410,5 @@ sentrie serve \
   --debug \
   --log-level DEBUG \
   --pack-location ./policies \
-  --port 3000
+  --http-port 3000
 ```

--- a/src/content/docs/getting-started.md
+++ b/src/content/docs/getting-started.md
@@ -212,7 +212,7 @@ policy pricing {
 
 **Invalid JSON**: Ensure your request body is valid JSON and matches the expected structure.
 
-**Server won't start**: Check that port 7529 is available, or use `--port` to specify a different port.
+**Server won't start**: Check that port 7529 is available, or use `--http-port` to specify a different port.
 
 ### Getting Help
 

--- a/src/content/docs/running-sentrie/serving-policies.md
+++ b/src/content/docs/running-sentrie/serving-policies.md
@@ -17,9 +17,9 @@ sentrie serve <policy-pack>
 
 ### Command Options
 
-- `--port` (default: `7529`): Port number to listen on
+- `--http-port` (default: `7529`): Port number to listen on
 - `--pack-location` (default: `./`): Directory containing the policy pack to serve
-- `--listen` (default: `["local"]`): Address(es) to listen on. Can be specified multiple times. Accepts:
+- `--http-listen` (default: `["local"]`): Address(es) to listen on. Can be specified multiple times. Accepts:
   - `local` - Listen on localhost (127.0.0.1)
   - `all` - Listen on all interfaces (0.0.0.0)
   - Comma-separated list of specific IP addresses or hostnames
@@ -31,16 +31,16 @@ sentrie serve <policy-pack>
 sentrie serve .
 
 # Serve a specific pack on a custom port
-sentrie serve --port 8080 /path/to/policy-pack
+sentrie serve --http-port 8080 /path/to/policy-pack
 
 # Listen on all interfaces
-sentrie serve --listen all --port 8080 .
+sentrie serve --http-listen all --http-port 8080 .
 
 # Listen on localhost only
-sentrie serve --listen local --port 8080 .
+sentrie serve --http-listen local --http-port 8080 .
 
 # Listen on multiple interfaces
-sentrie serve --listen 192.168.1.100,192.168.100.101 --port 8080 .
+sentrie serve --http-listen 192.168.1.100,192.168.100.101 --http-port 8080 .
 ```
 
 ## API Endpoints


### PR DESCRIPTION
## Summary

- Replaces legacy `serve` flag names in CLI docs and examples with the new HTTP-scoped flag names.
- Keeps defaults and behavior descriptions unchanged while aligning all user-facing documentation to the breaking CLI update.

## Changes

- Updated [`src/content/docs/cli-reference/index.md`](src/content/docs/cli-reference/index.md):
  - option tables and example commands now use `--http-port` and `--http-listen`.
- Updated [`src/content/docs/cli-reference/serve.md`](src/content/docs/cli-reference/serve.md):
  - flag sections, examples, and command snippets now use renamed flags.
- Updated [`src/content/docs/getting-started.md`](src/content/docs/getting-started.md):
  - troubleshooting guidance now references `--http-port`.
- Updated [`src/content/docs/running-sentrie/serving-policies.md`](src/content/docs/running-sentrie/serving-policies.md):
  - serve flag descriptions and usage examples now reference `--http-port` and `--http-listen`.

## Testing

- Performed repo-wide checks to ensure no `--port`/`--listen` references remain in website docs.
