### PR TITLE
Document pipeline operator semantics and precedence. Closes #24

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -158,6 +158,10 @@ export default defineConfig({
               slug: "reference/functions",
             },
             {
+              label: "Function chaining",
+              slug: "reference/function-chaining",
+            },
+            {
               label: "Using TypeScript",
               slug: "reference/using-typescript",
             },

--- a/src/content/docs/getting-started.md
+++ b/src/content/docs/getting-started.md
@@ -204,6 +204,18 @@ policy pricing {
 }
 ```
 
+### Readable Transformation Chains
+
+Use the pipeline operator when you want top-to-bottom transformation flow:
+
+```text
+let normalized = input
+  |> str.trim
+  |> str.toLower
+```
+
+This is equivalent to nested calls such as `str.toLower(str.trim(input))`. See the [Policy Language Reference](/reference) and [Precedence](/reference/precedence) pages for full rules and constraints.
+
 ## Troubleshooting
 
 ### Common Issues

--- a/src/content/docs/getting-started.md
+++ b/src/content/docs/getting-started.md
@@ -214,7 +214,7 @@ let normalized = input
   |> str.toLower
 ```
 
-This is equivalent to nested calls such as `str.toLower(str.trim(input))`. See the [Policy Language Reference](/reference) and [Precedence](/reference/precedence) pages for full rules and constraints.
+This is equivalent to nested calls such as `str.toLower(str.trim(input))`. See [Function chaining](/reference/function-chaining), the [Policy Language Reference](/reference), and [Precedence](/reference/precedence) for full rules and constraints.
 
 ## Troubleshooting
 

--- a/src/content/docs/reference/function-chaining.md
+++ b/src/content/docs/reference/function-chaining.md
@@ -25,8 +25,8 @@ let slug = str.replaceAll(t2, " ", "-")
 
 ```sentrie
 let slug = input
-  |> str.trim
-  |> str.toLower
+  |> str.trim()
+  |> str.toLower()
   |> str.replaceAll(" ", "-")
 ```
 
@@ -51,8 +51,8 @@ let slug = str.replaceAll(
 The parser lowers pipeline syntax to ordinary calls:
 
 ```text
-lhs |> ident            => ident(lhs)
-lhs |> alias.fn         => alias.fn(lhs)
+lhs |> ident()          => ident(lhs)
+lhs |> alias.fn()       => alias.fn(lhs)
 lhs |> ident(a, b)      => ident(lhs, a, b)
 lhs |> alias.fn(a, b)   => alias.fn(lhs, a, b)
 lhs |> fn(a, #, b)      => fn(a, lhs, b)
@@ -93,18 +93,18 @@ f(x, x)
 
 ### Style
 
-- Prefer straight chaining for sequential flow: `x |> g |> f`.
+- Prefer straight chaining for sequential flow: `x |> g() |> f()`.
 - Use `#` for non-first argument placement when needed.
-- Avoid readability regressions like `x |> f(g(#))` when `x |> g |> f` expresses the same logic more clearly.
+- Avoid readability regressions like `x |> f(g(#))` when `x |> g() |> f()` expresses the same logic more clearly.
 - `%` remains modulo in Sentrie and is unrelated to pipeline placeholders.
 
 ## Supported Targets
 
-The right-hand side of a pipeline must be one of:
+The right-hand side of a pipeline must be:
 
-- An identifier, for example `value |> count`
-- A module-qualified field access, for example `value |> str.trim`
-- A call expression whose callee is one of the above forms, for example `value |> str.replaceAll(" ", "-")`
+- A call expression whose callee is an identifier, for example `value |> count()`
+- A call expression whose callee is a module-qualified field access, for example `value |> str.trim()`
+- A call expression with explicit arguments, for example `value |> str.replaceAll(" ", "-")`
 
 ## Rejected Targets
 
@@ -124,7 +124,7 @@ value |> foo().bar
 `|>` has the lowest precedence and associates left-to-right.
 
 ```sentrie
-value |> str.trim |> count
+value |> str.trim() |> count()
 ```
 
 This lowers to:
@@ -140,18 +140,18 @@ For full operator ordering, see [Operator Precedence](/reference/precedence).
 Pipeline targets support the same memoization suffixes as ordinary calls:
 
 ```sentrie
-value |> count!30
-value |> str.trim!10
+value |> count()!30
+value |> str.trim()!10
 value |> str.replaceAll(" ", "-")!60
 ```
 
 - `!` enables memoization with default TTL.
 - `!<seconds>` enables memoization with an explicit TTL in seconds.
-- Supported on identifier targets, module-qualified field-access targets, and call targets.
+- Supported on call targets (including identifier and module-qualified callees).
 
 ## Parse-time vs Resolution-time
 
-`value |> trim` is valid syntax because `trim` is an identifier target form. Parse-time acceptance does not imply runtime resolution success.
+`value |> trim` is rejected at parse time because pipeline RHS targets must be explicit calls (for example `trim()`).
 
 Name resolution rules remain unchanged.
 
@@ -163,9 +163,9 @@ Pipelines do not inject imported symbols into local scope. `use` continues to bi
 use { trim } from @sentrie/string as str
 
 -- Valid: module-qualified access through alias
-let a = value |> str.trim
+let a = value |> str.trim()
 
--- Parses, but does not become resolvable because of `use`
+-- Rejected at parse time (RHS must be an explicit call)
 let b = value |> trim
 ```
 

--- a/src/content/docs/reference/function-chaining.md
+++ b/src/content/docs/reference/function-chaining.md
@@ -30,10 +30,6 @@ let slug = input
   |> str.replaceAll(" ", "-")
 ```
 
-::::note
-When a pipeline call target has **no** `#` placeholders, the parser inserts `lhs` as the **first positional** argument on the right.
-::::
-
 The pipeline example above is the same as this nested-call shape (parentheses show the order of application):
 
 ```sentrie
@@ -75,7 +71,9 @@ This lowers to:
 let out = str.replace(input, replaceChar, "$$")
 ```
 
-When `#` is present in the RHS argument list, the parser does not auto-prepend the piped value as argument 0.
+::::note
+When a pipeline call target has **no** `#` placeholders, the parser inserts `lhs` as the **first positional** argument on the right.
+::::
 
 ### Multiple placeholders
 

--- a/src/content/docs/reference/function-chaining.md
+++ b/src/content/docs/reference/function-chaining.md
@@ -31,7 +31,7 @@ let slug = input
 ```
 
 ::::note
-The parser desugars `lhs |> rhs(...)` by inserting `lhs` as the **first positional** argument of the call on the right. Any further arguments are exactly what you write after the callee, for example `|> str.replaceAll(" ", "-")`.
+When a pipeline call target has **no** `#` placeholders, the parser inserts `lhs` as the **first positional** argument on the right.
 ::::
 
 The pipeline example above is the same as this nested-call shape (parentheses show the order of application):
@@ -55,9 +55,48 @@ lhs |> ident            => ident(lhs)
 lhs |> alias.fn         => alias.fn(lhs)
 lhs |> ident(a, b)      => ident(lhs, a, b)
 lhs |> alias.fn(a, b)   => alias.fn(lhs, a, b)
+lhs |> fn(a, #, b)      => fn(a, lhs, b)
 ```
 
 Pipelines are parser sugar only. They do not introduce new runtime call semantics.
+
+## Placeholder (`#`) for Non-First Arguments
+
+Use `#` inside a pipeline call target when the piped value should go somewhere other than argument 0.
+
+```sentrie
+let replaceChar = "..."
+let out = replaceChar |> str.replace(input, #, "$$")
+```
+
+This lowers to:
+
+```sentrie
+let out = str.replace(input, replaceChar, "$$")
+```
+
+When `#` is present in the RHS argument list, the parser does not auto-prepend the piped value as argument 0.
+
+### Multiple placeholders
+
+All `#` placeholders in the same RHS call bind to the same piped value:
+
+```sentrie
+x |> f(#, #)
+```
+
+Lowers to:
+
+```sentrie
+f(x, x)
+```
+
+### Style
+
+- Prefer straight chaining for sequential flow: `x |> g |> f`.
+- Use `#` for non-first argument placement when needed.
+- Avoid readability regressions like `x |> f(g(#))` when `x |> g |> f` expresses the same logic more clearly.
+- `%` remains modulo in Sentrie and is unrelated to pipeline placeholders.
 
 ## Supported Targets
 

--- a/src/content/docs/reference/function-chaining.md
+++ b/src/content/docs/reference/function-chaining.md
@@ -1,11 +1,27 @@
 ---
-title: Pipeline Operator (`|>`)
-description: Use the pipeline operator for readable transformation chains, with precise rules for targets, desugaring, precedence, and memoization.
+title: Function chaining
+description: Chain calls with the `|>` pipeline operator—readable top-to-bottom flows, with rules for targets, desugaring, precedence, and memoization.
 ---
 
-The pipeline operator (`|>`) improves readability for expression chains by passing the left-hand expression as the first argument to the callable target on the right.
+When nested function calls pile up, it gets harder to see the data flow. You can always expand `g(f(x))` into separate `let` bindings, but that adds noise when the intermediate names are not the point.
 
-## Basic Syntax
+**Function chaining** in Sentrie uses the pipeline operator (`|>`) so the computation reads top-to-bottom: each step takes the value from the line above and passes it into the next call.
+
+### Nested calls
+
+```sentrie
+let slug = str.replaceAll(str.toLower(str.trim(input)), " ", "-")
+```
+
+### Intermediate values
+
+```sentrie
+let t1 = str.trim(input)
+let t2 = str.toLower(t1)
+let slug = str.replaceAll(t2, " ", "-")
+```
+
+### Pipeline
 
 ```sentrie
 let slug = input
@@ -14,7 +30,11 @@ let slug = input
   |> str.replaceAll(" ", "-")
 ```
 
-Equivalent nested-call form:
+::::note
+The parser desugars `lhs |> rhs(...)` by inserting `lhs` as the **first positional** argument of the call on the right. Any further arguments are exactly what you write after the callee, for example `|> str.replaceAll(" ", "-")`.
+::::
+
+The pipeline example above is the same as this nested-call shape (parentheses show the order of application):
 
 ```sentrie
 let slug = str.replaceAll(

--- a/src/content/docs/reference/functions.md
+++ b/src/content/docs/reference/functions.md
@@ -55,6 +55,80 @@ use { sha256 } from @sentrie/hash
 
 :::
 
+### Pipeline Operator (`|>`)
+
+Sentrie supports a pipeline operator for readability when chaining transformations. The value on the left is passed as the first argument to the callable on the right.
+
+```sentrie
+let slug = input
+  |> str.trim
+  |> str.toLower
+  |> str.replaceAll(" ", "-")
+```
+
+This is equivalent to:
+
+```sentrie
+let slug = str.replaceAll(
+  str.toLower(
+    str.trim(input),
+  ),
+  " ",
+  "-",
+)
+```
+
+#### Supported pipeline targets
+
+The right-hand side of a pipeline must be one of:
+
+- A built-in identifier, for example `value |> count`
+- A module-qualified field access, for example `value |> str.trim`
+- A call expression whose callee is one of the two forms above, for example `value |> str.replaceAll(" ", "-")`
+
+#### Pipeline memoization
+
+Pipeline targets support memoization suffixes with the same semantics as ordinary calls:
+
+```sentrie
+value |> count!30
+value |> str.trim!10
+value |> str.replaceAll(" ", "-")!60
+```
+
+- `!` enables memoization with default TTL.
+- `!<seconds>` enables memoization with an explicit TTL in seconds.
+- This works for identifier targets, module-qualified field-access targets, and call targets.
+
+#### Rejected pipeline targets
+
+The right-hand side is rejected when its callable root is not an identifier or a module-qualified field access. For example:
+
+```sentrie
+value |> (a + b)
+value |> foo ? bar : baz
+value |> foo[0]
+value |> foo().bar
+```
+
+#### Parse-time vs resolution-time
+
+`value |> trim` is valid syntax because `trim` is an identifier target form. However, parse-time acceptance does not imply that `trim` resolves successfully at runtime. Name resolution rules remain unchanged.
+
+#### `use` behavior does not change
+
+Pipelines do not inject imported symbols into local scope. `use` still binds module aliases only.
+
+```sentrie
+use { trim } from @sentrie/string as str
+
+-- Valid: module-qualified call through alias
+let a = value |> str.trim
+
+-- Parses as syntax, but does not become resolvable just because of `use`
+let b = value |> trim
+```
+
 ## TypeScript Module Functions
 
 Sentrie allows you to import and use functions from TypeScript modules, including built-in `@sentrie/*` modules and your own local TypeScript files. This provides extensive functionality for cryptography, data manipulation, time operations, and more.

--- a/src/content/docs/reference/functions.md
+++ b/src/content/docs/reference/functions.md
@@ -55,11 +55,11 @@ use { sha256 } from @sentrie/hash
 
 :::
 
-### Pipeline Operator (`|>`)
+### Function chaining (`|>`)
 
 Use `|>` to build readable transformation chains by passing the left value as the first argument to the callable on the right.
 
-See [Pipeline Operator (`|>`)](/reference/pipeline-operator).
+See [Function chaining](/reference/function-chaining).
 
 ## TypeScript Module Functions
 

--- a/src/content/docs/reference/functions.md
+++ b/src/content/docs/reference/functions.md
@@ -188,7 +188,7 @@ Avoid memoization for functions that:
 - Have side effects that must execute each time
   :::
 
-### Function chaining (`|>`)
+## Function chaining (`|>`)
 
 The pipeline operator `|>` passes the left value into the next function call, allowing clear, top-to-bottom transformation chains:
 

--- a/src/content/docs/reference/functions.md
+++ b/src/content/docs/reference/functions.md
@@ -57,77 +57,9 @@ use { sha256 } from @sentrie/hash
 
 ### Pipeline Operator (`|>`)
 
-Sentrie supports a pipeline operator for readability when chaining transformations. The value on the left is passed as the first argument to the callable on the right.
+Use `|>` to build readable transformation chains by passing the left value as the first argument to the callable on the right.
 
-```sentrie
-let slug = input
-  |> str.trim
-  |> str.toLower
-  |> str.replaceAll(" ", "-")
-```
-
-This is equivalent to:
-
-```sentrie
-let slug = str.replaceAll(
-  str.toLower(
-    str.trim(input),
-  ),
-  " ",
-  "-",
-)
-```
-
-#### Supported pipeline targets
-
-The right-hand side of a pipeline must be one of:
-
-- A built-in identifier, for example `value |> count`
-- A module-qualified field access, for example `value |> str.trim`
-- A call expression whose callee is one of the two forms above, for example `value |> str.replaceAll(" ", "-")`
-
-#### Pipeline memoization
-
-Pipeline targets support memoization suffixes with the same semantics as ordinary calls:
-
-```sentrie
-value |> count!30
-value |> str.trim!10
-value |> str.replaceAll(" ", "-")!60
-```
-
-- `!` enables memoization with default TTL.
-- `!<seconds>` enables memoization with an explicit TTL in seconds.
-- This works for identifier targets, module-qualified field-access targets, and call targets.
-
-#### Rejected pipeline targets
-
-The right-hand side is rejected when its callable root is not an identifier or a module-qualified field access. For example:
-
-```sentrie
-value |> (a + b)
-value |> foo ? bar : baz
-value |> foo[0]
-value |> foo().bar
-```
-
-#### Parse-time vs resolution-time
-
-`value |> trim` is valid syntax because `trim` is an identifier target form. However, parse-time acceptance does not imply that `trim` resolves successfully at runtime. Name resolution rules remain unchanged.
-
-#### `use` behavior does not change
-
-Pipelines do not inject imported symbols into local scope. `use` still binds module aliases only.
-
-```sentrie
-use { trim } from @sentrie/string as str
-
--- Valid: module-qualified call through alias
-let a = value |> str.trim
-
--- Parses as syntax, but does not become resolvable just because of `use`
-let b = value |> trim
-```
+See [Pipeline Operator (`|>`)](/reference/pipeline-operator).
 
 ## TypeScript Module Functions
 

--- a/src/content/docs/reference/functions.md
+++ b/src/content/docs/reference/functions.md
@@ -55,12 +55,6 @@ use { sha256 } from @sentrie/hash
 
 :::
 
-### Function chaining (`|>`)
-
-Use `|>` to build readable transformation chains by passing the left value as the first argument to the callable on the right.
-
-See [Function chaining](/reference/function-chaining).
-
 ## TypeScript Module Functions
 
 Sentrie allows you to import and use functions from TypeScript modules, including built-in `@sentrie/*` modules and your own local TypeScript files. This provides extensive functionality for cryptography, data manipulation, time operations, and more.
@@ -193,6 +187,19 @@ Avoid memoization for functions that:
 - Need to return fresh data on every call
 - Have side effects that must execute each time
   :::
+
+### Function chaining (`|>`)
+
+The pipeline operator `|>` passes the left value into the next function call, allowing clear, top-to-bottom transformation chains:
+
+```sentrie
+let slug = input
+  |> str.trim()
+  |> str.toLower()
+  |> str.replaceAll(" ", "-")
+```
+
+Use `#` in the right-hand call to put the piped value anywhere in the argument list. See [Function chaining](/reference/function-chaining) for all details.
 
 ## Using Functions in Rules and Let Declarations
 

--- a/src/content/docs/reference/index.md
+++ b/src/content/docs/reference/index.md
@@ -16,7 +16,7 @@ This is the complete reference for the Sentrie policy language. It covers all la
 - [Literals](#literals)
 - [Operators](#operators)
 - [Control Flow](#control-flow)
-- [Pipeline Operator](/reference/pipeline-operator) - Detailed reference for pipeline syntax, desugaring, precedence, and memoization
+- [Function chaining](/reference/function-chaining) - Pipeline operator (`|>`), desugaring, precedence, and memoization
 - [TypeScript Modules](#typescript-modules)
 - [Facts and Variables](#facts-and-variables)
 - [Exports and Imports](#exports-and-imports)
@@ -409,7 +409,7 @@ null        -- Null value
 |>          -- Pipe left expression into callable target on the right
 ```
 
-For complete rules and examples, see [Pipeline Operator (`|>`)](/reference/pipeline-operator).
+For complete rules and examples, see [Function chaining](/reference/function-chaining).
 
 ### Comparison Operators
 

--- a/src/content/docs/reference/index.md
+++ b/src/content/docs/reference/index.md
@@ -182,6 +182,7 @@ Sentrie has a rich expression language with multiple operator types and preceden
 8. **Logical XOR**: `xor`
 9. **Logical OR**: `or`
 10. **Ternary**: `? :`
+11. **Pipeline**: `|>` (lowest precedence)
 
 ### Primary Expressions
 
@@ -206,6 +207,10 @@ config.maxRetries
 time.now()
 hash.sha256("data")
 json.parse("{}")
+
+-- Pipeline calls
+value |> len
+value |> str.trim |> len
 
 -- Index access
 users[0]
@@ -397,6 +402,49 @@ null        -- Null value
 %           -- Modulo
 ```
 
+### Pipeline Operator
+
+```text
+|>          -- Pipe left expression into callable target on the right
+```
+
+Pipeline desugaring rules:
+
+```text
+lhs |> ident            => ident(lhs)
+lhs |> alias.fn         => alias.fn(lhs)
+lhs |> ident(a, b)      => ident(lhs, a, b)
+lhs |> alias.fn(a, b)   => alias.fn(lhs, a, b)
+```
+
+Pipeline memoization rules:
+
+```text
+lhs |> ident!           => memoized ident(lhs)
+lhs |> alias.fn!30      => memoized alias.fn(lhs) with 30s TTL
+lhs |> ident(a)!60      => memoized ident(lhs, a) with 60s TTL
+```
+
+Right-hand side validity:
+
+- Allowed: identifiers, module-qualified field access, and calls on those targets
+- Rejected: grouped/infix/ternary/list/map/index targets, or field access rooted in non-identifiers
+
+```text
+-- Valid
+value |> len
+value |> str.trim
+value |> str.replaceAll(" ", "-")
+
+-- Invalid
+value |> (a + b)
+value |> foo ? bar : baz
+value |> foo[0]
+value |> foo().bar
+```
+
+`value |> trim` can parse because `trim` is an identifier form, but parse-time acceptance does not guarantee name resolution at runtime.
+
 ### Comparison Operators
 
 ```text
@@ -479,6 +527,8 @@ use { function1, function2 } from @sentrie/module as alias
 **Note:** Built-in `@sentrie/*` modules do not use quotes. Local TypeScript files use quotes for relative paths.
 
 The `as` clause is optional. If omitted, the default alias is the last part of the module path (e.g., `time` for `@sentrie/time`).
+
+`use` semantics do not change with pipelines: imported names are not injected into local scope, and module-qualified calls remain the canonical form.
 
 ### Built-in Modules
 

--- a/src/content/docs/reference/index.md
+++ b/src/content/docs/reference/index.md
@@ -16,6 +16,7 @@ This is the complete reference for the Sentrie policy language. It covers all la
 - [Literals](#literals)
 - [Operators](#operators)
 - [Control Flow](#control-flow)
+- [Pipeline Operator](/reference/pipeline-operator) - Detailed reference for pipeline syntax, desugaring, precedence, and memoization
 - [TypeScript Modules](#typescript-modules)
 - [Facts and Variables](#facts-and-variables)
 - [Exports and Imports](#exports-and-imports)
@@ -408,42 +409,7 @@ null        -- Null value
 |>          -- Pipe left expression into callable target on the right
 ```
 
-Pipeline desugaring rules:
-
-```text
-lhs |> ident            => ident(lhs)
-lhs |> alias.fn         => alias.fn(lhs)
-lhs |> ident(a, b)      => ident(lhs, a, b)
-lhs |> alias.fn(a, b)   => alias.fn(lhs, a, b)
-```
-
-Pipeline memoization rules:
-
-```text
-lhs |> ident!           => memoized ident(lhs)
-lhs |> alias.fn!30      => memoized alias.fn(lhs) with 30s TTL
-lhs |> ident(a)!60      => memoized ident(lhs, a) with 60s TTL
-```
-
-Right-hand side validity:
-
-- Allowed: identifiers, module-qualified field access, and calls on those targets
-- Rejected: grouped/infix/ternary/list/map/index targets, or field access rooted in non-identifiers
-
-```text
--- Valid
-value |> len
-value |> str.trim
-value |> str.replaceAll(" ", "-")
-
--- Invalid
-value |> (a + b)
-value |> foo ? bar : baz
-value |> foo[0]
-value |> foo().bar
-```
-
-`value |> trim` can parse because `trim` is an identifier form, but parse-time acceptance does not guarantee name resolution at runtime.
+For complete rules and examples, see [Pipeline Operator (`|>`)](/reference/pipeline-operator).
 
 ### Comparison Operators
 

--- a/src/content/docs/reference/pipeline-operator.md
+++ b/src/content/docs/reference/pipeline-operator.md
@@ -1,0 +1,117 @@
+---
+title: Pipeline Operator (`|>`)
+description: Use the pipeline operator for readable transformation chains, with precise rules for targets, desugaring, precedence, and memoization.
+---
+
+The pipeline operator (`|>`) improves readability for expression chains by passing the left-hand expression as the first argument to the callable target on the right.
+
+## Basic Syntax
+
+```sentrie
+let slug = input
+  |> str.trim
+  |> str.toLower
+  |> str.replaceAll(" ", "-")
+```
+
+Equivalent nested-call form:
+
+```sentrie
+let slug = str.replaceAll(
+  str.toLower(
+    str.trim(input),
+  ),
+  " ",
+  "-",
+)
+```
+
+## Desugaring Rules
+
+The parser lowers pipeline syntax to ordinary calls:
+
+```text
+lhs |> ident            => ident(lhs)
+lhs |> alias.fn         => alias.fn(lhs)
+lhs |> ident(a, b)      => ident(lhs, a, b)
+lhs |> alias.fn(a, b)   => alias.fn(lhs, a, b)
+```
+
+Pipelines are parser sugar only. They do not introduce new runtime call semantics.
+
+## Supported Targets
+
+The right-hand side of a pipeline must be one of:
+
+- An identifier, for example `value |> count`
+- A module-qualified field access, for example `value |> str.trim`
+- A call expression whose callee is one of the above forms, for example `value |> str.replaceAll(" ", "-")`
+
+## Rejected Targets
+
+The right-hand side is rejected when its callable root is not an identifier or module-qualified field access.
+
+Examples of rejected forms:
+
+```sentrie
+value |> (a + b)
+value |> foo ? bar : baz
+value |> foo[0]
+value |> foo().bar
+```
+
+## Precedence and Associativity
+
+`|>` has the lowest precedence and associates left-to-right.
+
+```sentrie
+value |> str.trim |> count
+```
+
+This lowers to:
+
+```sentrie
+count(str.trim(value))
+```
+
+For full operator ordering, see [Operator Precedence](/reference/precedence).
+
+## Memoization
+
+Pipeline targets support the same memoization suffixes as ordinary calls:
+
+```sentrie
+value |> count!30
+value |> str.trim!10
+value |> str.replaceAll(" ", "-")!60
+```
+
+- `!` enables memoization with default TTL.
+- `!<seconds>` enables memoization with an explicit TTL in seconds.
+- Supported on identifier targets, module-qualified field-access targets, and call targets.
+
+## Parse-time vs Resolution-time
+
+`value |> trim` is valid syntax because `trim` is an identifier target form. Parse-time acceptance does not imply runtime resolution success.
+
+Name resolution rules remain unchanged.
+
+## `use` Behavior Is Unchanged
+
+Pipelines do not inject imported symbols into local scope. `use` continues to bind module aliases.
+
+```sentrie
+use { trim } from @sentrie/string as str
+
+-- Valid: module-qualified access through alias
+let a = value |> str.trim
+
+-- Parses, but does not become resolvable because of `use`
+let b = value |> trim
+```
+
+## See Also
+
+- [Using Functions](/reference/functions)
+- [Operator Precedence](/reference/precedence)
+- [Policy Language Reference](/reference/)

--- a/src/content/docs/reference/precedence.md
+++ b/src/content/docs/reference/precedence.md
@@ -7,18 +7,19 @@ Operator precedence defines which operations are performed first when multiple o
 
 ## Precedence Table (highest to lowest)
 
-| Precedence | Operators                                         | Description                                                 |
-| ---------- | ------------------------------------------------- | ----------------------------------------------------------- |
+| Precedence | Operators                                         | Description                                                  |
+| ---------- | ------------------------------------------------- | ------------------------------------------------------------ |
 | 1          | `()`, `[]`, `.`                                   | Primary expressions (literals, identifiers, function calls) |
-| 2          | `not`, `!`, `+`, `-`                              | Unary operators                                             |
-| 3          | `*`, `/`, `%`                                     | Multiplicative arithmetic                                   |
-| 4          | `+`, `-`                                          | Additive arithmetic                                         |
-| 5          | `<`, `<=`, `>`, `>=`, `in`, `matches`, `contains` | Comparison operators                                        |
-| 6          | `==`, `!=`, `is`, `is not`                        | Equality operators                                          |
-| 7          | `and`                                             | Logical AND                                                 |
-| 8          | `xor`                                             | Logical XOR                                                 |
-| 9          | `or`                                              | Logical OR                                                  |
-| 10         | `? :`                                             | Ternary conditional                                         |
+| 2          | `not`, `!`, `+`, `-`                              | Unary operators                                              |
+| 3          | `*`, `/`, `%`                                     | Multiplicative arithmetic                                    |
+| 4          | `+`, `-`                                          | Additive arithmetic                                          |
+| 5          | `<`, `<=`, `>`, `>=`, `in`, `matches`, `contains` | Comparison operators                                         |
+| 6          | `==`, `!=`, `is`, `is not`                        | Equality operators                                           |
+| 7          | `and`                                             | Logical AND                                                  |
+| 8          | `xor`                                             | Logical XOR                                                  |
+| 9          | `or`                                              | Logical OR                                                   |
+| 10         | `? :`                                             | Ternary conditional                                          |
+| 11         | `|>`                                              | Pipeline operator (lowest precedence)                        |
 
 ## Examples
 
@@ -48,6 +49,21 @@ let mixed: bool = 5 > 3 and 2 < 4           -- Result: true
 ```sentrie
 let value: number = 5 > 3 ? 10 : 20                       -- Result: 10
 let nested: string = true ? (false ? "A" : "B") : "C"  -- Result: "B"
+```
+
+### Pipeline Precedence and Associativity
+
+The pipeline operator has the lowest precedence and associates from left to right.
+
+```sentrie
+let a = value |> len |> math.abs
+-- Equivalent to: math.abs(len(value))
+
+let b = a + b |> len
+-- Equivalent to: len(a + b)
+
+let c = cond ? x : y |> len
+-- Equivalent to: len(cond ? x : y)
 ```
 
 ## Using Parentheses

--- a/src/content/docs/reference/precedence.md
+++ b/src/content/docs/reference/precedence.md
@@ -66,6 +66,8 @@ let c = cond ? x : y |> len
 -- Equivalent to: len(cond ? x : y)
 ```
 
+For pipeline syntax, valid targets, and memoization, see [Function chaining](/reference/function-chaining).
+
 ## Using Parentheses
 
 ### Override Precedence


### PR DESCRIPTION
## Summary

- Adds a standalone pipeline operator reference page with complete syntax and behavior details.
- Keeps `functions` and top-level `reference` docs concise by linking to the dedicated page.
- Preserves existing guidance on precedence, desugaring, memoization, and `use`/resolution boundaries in a single canonical location.

## Changes

- Added [`src/content/docs/reference/pipeline-operator.md`](src/content/docs/reference/pipeline-operator.md):
  - comprehensive page for `|>` syntax, desugaring, supported/rejected targets, precedence/associativity, memoization, and resolution semantics.
- Updated [`src/content/docs/reference/functions.md`](src/content/docs/reference/functions.md):
  - replaced the long inline pipeline section with a short introduction and a pointer to the dedicated pipeline reference page.
- Updated [`src/content/docs/reference/index.md`](src/content/docs/reference/index.md):
  - added a table-of-contents link to the dedicated pipeline page and simplified the pipeline operator subsection.

## Testing

- Documentation-only change; verified markdown consistency and internal links for the new dedicated page layout.
