### PR TITLE
Update docs for shape optionality and T? nullability Closes #30

### DIFF
--- a/src/content/docs/getting-started/writing-your-first-policy.md
+++ b/src/content/docs/getting-started/writing-your-first-policy.md
@@ -130,7 +130,7 @@ policy user_access {
 - Facts are **required by default** - they must be provided during execution
 - Use `?` to mark facts as **optional** - optional facts can be omitted
 - Only **optional facts** (`?`) can have default values
-- Facts are **always non-nullable** - null values are not allowed
+- Facts can use nullable types (`T?`) when explicit `null` values are allowed
   :::
 
 ## Add your first rule

--- a/src/content/docs/reference/arithmetic-operations.md
+++ b/src/content/docs/reference/arithmetic-operations.md
@@ -78,8 +78,8 @@ All numeric values are handled uniformly as the `number` type.
 
 ```sentrie
 shape Rectangle {
-  width!: number
-  height!: number
+  width: number
+  height: number
 }
 
 fact rect: Rectangle

--- a/src/content/docs/reference/boolean-operations.md
+++ b/src/content/docs/reference/boolean-operations.md
@@ -51,9 +51,9 @@ let can_access: bool = user_role == "admin" ? true : false
 
 ```sentrie
 shape Product {
-  name!: string
-  price!: number
-  category!: string
+  name: string
+  price: number
+  category: string
   in_stock: bool
 }
 
@@ -402,7 +402,7 @@ let list_is_not_empty: bool = non_empty_list is not empty
 
 ```sentrie
 shape User {
-  name!: string
+  name: string
   email?: string
   phone?: string
 }
@@ -436,7 +436,7 @@ value is not defined
 
 ```sentrie
 shape User {
-  name!: string
+  name: string
   email?: string
   phone?: string
 }
@@ -463,8 +463,8 @@ let display_email: string = user.email is defined ? user.email : "No email provi
 
 ```sentrie
 shape Order {
-  id!: string
-  customer_name!: string
+  id: string
+  customer_name: string
   customer_email?: string
   customer_phone?: string
   shipping_address?: string
@@ -500,9 +500,9 @@ let contact_method: string = order.customer_email is defined ?
 
 ```sentrie
 shape User {
-  id!: string
-  username!: string
-  role!: string
+  id: string
+  username: string
+  role: string
   age: number
   email?: string
   active: bool
@@ -510,8 +510,8 @@ shape User {
 }
 
 shape Resource {
-  id!: string
-  name!: string
+  id: string
+  name: string
   required_role: string
   min_age: number
   required_permissions: list[string]
@@ -552,9 +552,9 @@ let can_access: bool = user.active and
 use {length} from @sentrie/js as str
 
 shape RegistrationData {
-  username!: string
+  username: string
   email?: string
-  password!: string
+  password: string
   age: number
   terms_accepted: bool
 }

--- a/src/content/docs/reference/built-in-functions.md
+++ b/src/content/docs/reference/built-in-functions.md
@@ -186,9 +186,9 @@ let has_perfect_score: bool = any(scores, (score) => {
 })
 
 shape User {
-  name!: string
+  name: string
   age: number
-  role!: string
+  role: string
 }
 
 let users: list[User] = [
@@ -243,9 +243,9 @@ let even_indexed: list[number] = filter(numbers, (num, idx) => {
 })
 
 shape Employee {
-  name!: string
-  department!: string
-  salary!: number
+  name: string
+  department: string
+  salary: number
 }
 
 let employees: list[Employee] = [
@@ -302,7 +302,7 @@ let indexed_fruits: list[string] = collect(fruits, (fruit, idx) => {
 })
 
 shape User {
-  name!: string
+  name: string
   age: number
 }
 
@@ -345,9 +345,9 @@ let sentence: string = reduce(words, "", (acc, word, idx) => {
 })
 
 shape Sale {
-  product!: string
-  quantity!: number
-  price!: number
+  product: string
+  quantity: number
+  price: number
 }
 
 let sales: list[Sale] = [
@@ -387,7 +387,7 @@ distinct(list, (element, index) => { yield keyExpression })
 
 ```sentrie
 shape Person {
-  name!: string
+  name: string
   age: number
 }
 
@@ -408,10 +408,10 @@ Nest builtins for multi-step transforms. Intermediate `let` bindings often read 
 
 ```sentrie
 shape Employee {
-  name!: string
+  name: string
   age: number
-  department!: string
-  salary!: number
+  department: string
+  salary: number
   years_experience: number
 }
 

--- a/src/content/docs/reference/facts.md
+++ b/src/content/docs/reference/facts.md
@@ -26,7 +26,7 @@ fact <name>?: <type> ('as' <exposed_name>)? ('default' <default_value>)?
 - If no `as` clause is provided, the fact name itself is used as the exposed name
 - The `default` clause is only allowed for optional facts (marked with `?`)
 - Facts are **required by default** - use `?` to make them optional
-- Facts are **always non-nullable** - null values are not allowed
+- Facts can use nullable types with `T?` when explicit `null` is allowed
 :::
 
 ### Required vs Optional Facts
@@ -41,8 +41,8 @@ fact context?: Context as context default { "key": "value" }
 
 :::note[Important]
 - **Facts are required by default** - If no modifier is specified, the fact must be provided during execution
-- **Use `?` to mark facts as optional** - Optional facts can be omitted, but if provided, they must be non-null
-- **Facts are always non-nullable** - Null values are not allowed for facts
+- **Use `?` to mark facts as optional** - Optional facts can be omitted
+- **Use `T?` to allow null values** - Bare `T` remains non-null by default
 - **Required facts cannot have default values** - Only optional facts can have defaults
 - **Facts before uses:** If a policy has both `fact` and `use` statements, every `fact` must appear before the first `use`. A policy may have **uses with no facts** (skip the facts block).
 
@@ -78,9 +78,9 @@ fact coordinates?: record[number, number] as location default [ 0.0, 0.0 ]
 
 ```sentrie
 shape User {
-  id!: string
-  role!: string
-  permissions!: list[string]
+  id: string
+  role: string
+  permissions: list[string]
 }
 
 -- Required shape fact
@@ -120,8 +120,8 @@ fact context?: Context as context default { "key": "value" }
 ```
 
 :::warning[Important]
-- Facts are **always non-nullable** - Even if a fact is optional, if it is provided, it cannot be null
-- The `!` operator is **not supported** for facts - facts are always non-nullable by design
+- `T?` allows explicit `null` values for facts
+- Legacy `!` syntax is not supported
 - Only **optional facts** (`?`) can have default values
 :::
 
@@ -160,9 +160,9 @@ fact name: string as userName default "anonymous"  -- Error: required fact canno
 
 ```sentrie
 shape Product {
-  id!: string
-  name!: string
-  price!: number
+  id: string
+  name: string
+  price: number
 }
 
 -- Optional fact with shape default
@@ -206,9 +206,9 @@ fact user?: User as user default { "id": 123 }  -- Error: string expected, got n
 -- Correct usage
 fact user?: User as user default { "id": "123" }
 
--- Null validation: Facts cannot be null
--- This will cause a runtime error if null is provided
-fact user: User as user  -- If null is provided, error: "fact 'user' cannot be null"
+-- Null validation depends on type nullability
+fact user: User as user   -- null is invalid
+fact user: User? as user  -- null is valid
 ```
 
 ## Best Practices
@@ -231,7 +231,7 @@ fact data?: User as d default { "id": "", "role": "guest" }
 fact user?: User as user default { "id": "anonymous", "role": "guest", "permissions": [] }
 
 -- Avoid: Confusing or invalid defaults
-fact user?: User as user default { "id": "", "role": "invalid", "permissions": null }  -- null not allowed
+fact user?: User as user default { "id": "", "role": "invalid", "permissions": null }  -- invalid because permissions is list[string]
 ```
 
 ### Use Required Facts Appropriately

--- a/src/content/docs/reference/index.md
+++ b/src/content/docs/reference/index.md
@@ -343,26 +343,28 @@ Sentrie provides primitives, collections, shapes, and aliases for defining data 
 
 Shapes define structured data with fields and constraints.
 
-**Field Modifiers:**
+**Field Contract Matrix:**
 
-- `!` - Non-nullable (required field)
-- `?` - Optional field
-- No modifier - Default field (required by default)
+- `field: T` - required, non-null
+- `field?: T` - optional, if present non-null
+- `field: T?` - required, nullable
+- `field?: T?` - optional, nullable
 
 ```text
 shape User {
-  id!: string           -- Required field (non-nullable)
-  name!: string         -- Required field (non-nullable)
-  email?: string        -- Optional field
-  age?: number          -- Optional field
-  roles: list[string]   -- Required field (default)
-  metadata: document    -- Required field (default)
+  id: string
+  name: string
+  email?: string
+  middle_name: string?
+  nickname?: string?
+  roles: list[string]
+  metadata: document
 }
 
 shape Product {
-  id!: string
-  name!: string
-  price!: number
+  id: string
+  name: string
+  price: number
   tags?: list[string]
   dimensions: record[number, number, number]  -- width, height, depth
 }
@@ -374,8 +376,8 @@ Shapes can be composed from other shapes using the `with` keyword:
 
 ```text
 shape BaseUser {
-  id!: string
-  name!: string
+  id: string
+  name: string
 }
 
 shape AdminUser with BaseUser {
@@ -584,7 +586,7 @@ Built-in modules are prefixed with `@sentrie/`:
 namespace com/example/auth
 
 policy mypolicy {
-  fact data!: string
+  fact data: string
 
   use { now } from @sentrie/time as time
   use { sha256 } from @sentrie/hash
@@ -609,7 +611,7 @@ You can import TypeScript files from your policy pack using relative paths:
 namespace com/example/auth
 
 policy mypolicy {
-  fact user!: User
+  fact user: User
 
   use { calculateAge, validateEmail } from "./utils.ts" as utils
 
@@ -671,7 +673,7 @@ Facts can have:
 
 - Facts are **required by default** - must be provided during execution
 - Use `?` to mark facts as **optional** - can be omitted
-- Facts are **always non-nullable** - null values are not allowed
+- Facts can also use nullable types with `T?` when explicit `null` is valid
 - Only **optional facts** (`?`) can have default values
   :::
 
@@ -865,9 +867,9 @@ rule validateUser = default false when user is defined {
 
 ```text
 shape User {
-  id!: string
-  name!: string
-  role!: string
+  id: string
+  name: string
+  role: string
 }
 
 rule processUser = default false when user is User {

--- a/src/content/docs/reference/policies.md
+++ b/src/content/docs/reference/policies.md
@@ -56,15 +56,15 @@ policy policyName {
 namespace com/example/auth
 
 shape User {
-  id!: string
-  role!: string
-  permissions!: list[string]
+  id: string
+  role: string
+  permissions: list[string]
 }
 
 shape Resource {
-  id!: string
-  type!: string
-  owner!: string
+  id: string
+  type: string
+  owner: string
 }
 
 policy userAccess {
@@ -125,7 +125,7 @@ fact config?: Config as settings default { "environment": "production" }
 - Facts are **required by default** - must be provided during execution
 - Use `?` to mark facts as **optional** - can be omitted
 - Only **optional facts** (`?`) can have default values
-- Facts are **always non-nullable** - null values are not allowed
+- Facts can use nullable types (`T?`) when explicit `null` values are allowed
   :::
 
 :::note

--- a/src/content/docs/reference/rules.md
+++ b/src/content/docs/reference/rules.md
@@ -66,7 +66,7 @@ Exported rules can include named attachments that provide additional context or 
 namespace com/example/auth
 
 policy base {
-  fact user!:User as u -- alias for the user fact
+  fact user: User as u -- alias for the user fact
 
   rule isAdmin = default false when user.role is defined {
     yield user.role is "admin" or user.role is "super_admin"
@@ -80,7 +80,7 @@ policy base {
 namespace com/example/user
 
 policy user_access {
-  fact user!:User as user
+  fact user: User as user
 
   rule isAdmin = import decision of isAdmin from com/example/auth/base with u as user
 }
@@ -151,11 +151,11 @@ Rules become powerful when composed across policies. Here's how to export a deci
 namespace com/example/auth
 
 shape Account {
-  balance!: number
+  balance: number
 }
 
 shape Invoice {
-  total!: number
+  total: number
 }
 ```
 
@@ -164,8 +164,8 @@ shape Invoice {
 namespace com/example/billing
 
 policy billing {
-  fact account!: Account as account
-  fact invoice!: Invoice as invoice
+  fact account: Account as account
+  fact invoice: Invoice as invoice
 
   let reason = account.balance >= invoice.total ? "insufficient_funds" : "sufficient_funds"
   let balance = account.balance
@@ -184,8 +184,8 @@ When importing this decision, you inject the necessary facts and receive the dec
 
 ```sentrie
 policy shipping {
-  fact account!: Account as account
-  fact invoice!: Invoice as invoice
+  fact account: Account as account
+  fact invoice: Invoice as invoice
 
   rule payment_reason_consumed = import decision of payment_ok from com/example/billing
     with account as account

--- a/src/content/docs/reference/shapes.md
+++ b/src/content/docs/reference/shapes.md
@@ -59,56 +59,69 @@ let user: User = {
 }
 ```
 
-#### Field Nullability and Optionality
+#### Field Optionality and Nullability
 
-Shapes support different field requirements using special markers:
+Sentrie models field contracts on two independent axes:
 
-- **Required fields** (default): Field must be present and can be null
-- **Required non-null fields** (`!`): Field must be present and cannot be null
-- **Optional fields** (`?`): Field may be omitted entirely
+- `field?` controls **presence** (whether the field may be absent)
+- `T?` controls **value nullability** (whether the present value may be `null`)
+
+The canonical shape field matrix is:
+
+- `field: T` -> required, non-null
+- `field?: T` -> optional, if present non-null
+- `field: T?` -> required, nullable
+- `field?: T?` -> optional, nullable
 
 ```sentrie
-shape User {
-  name!: string           -- Required, cannot be null
-  age: number                -- Required, can be null
-  email?: string          -- Optional, can be omitted
-  phone!?: string         -- Optional, but if present cannot be null
+shape Person {
+  name: string
+  age: number
+  gender?: string
+  middle_name: string?
+  nickname?: string?
 }
 ```
 
-Examples of valid and invalid usage:
+Examples:
 
 ```sentrie
--- Valid: all required fields present, optional field omitted
-let user1: User = {
+-- Valid: required fields are present and non-null
+let p1: Person = {
   name: "Alice",
-  age: 25
+  age: 25,
 }
 
--- Valid: all fields present, including optional
-let user2: User = {
+-- Valid: nullable required field present as null
+let p2: Person = {
   name: "Bob",
   age: 30,
-  email: "bob@example.com"
+  middle_name: null
 }
 
--- Valid: required field can be null
-let user3: User = {
+-- Valid: optional nullable field omitted
+let p3: Person = {
   name: "Charlie",
-  age: null
+  age: 32,
 }
 
--- Invalid: required non-null field is null
-let user4: User = {
-  name: null,  -- Error: name cannot be null
-  age: 25
+-- Invalid: required non-null field cannot be null
+let bad1: Person = {
+  name: null,
+  age: 22
 }
 
--- Invalid: required field is missing
-let user5: User = {
-  age: 25  -- Error: name is required
+-- Invalid: required field cannot be absent
+let bad2: Person = {
+  age: 22
 }
 ```
+
+Migration note:
+
+- `field!: T` -> `field: T`
+- `field!?: T` / `field?!: T` -> `field?: T?`
+- if old `field: T` relied on nullable behavior, write `field: T?`
 
 :::note[Checking Optional Fields]
 You can check if optional fields are defined using the `is defined` operator:
@@ -123,6 +136,7 @@ let user: User = {
 -- You can also use this in boolean expressions
 let has_phone: bool = user.phone is defined
 let contact_info: string = user.phone is defined ? user.phone : "No phone available"
+let display_gender: string = user.gender ?: "unknown"
 
 -- Check if optional fields exist using ternary operator
 let phone_message: string = user.phone is defined ? "Phone: " + user.phone : "No phone number provided"
@@ -214,23 +228,23 @@ Shapes excel at modeling complex, nested data models with proper nullability han
 
 ```sentrie
 shape Address {
-  street!: string @not_empty()
-  city!: string @not_empty()
-  state!: string @length(2) @uppercase()
-  zip!: string @regexp("^[0-9]{5}(-[0-9]{4})?$")
+  street: string @not_empty()
+  city: string @not_empty()
+  state: string @length(2) @uppercase()
+  zip: string @regexp("^[0-9]{5}(-[0-9]{4})?$")
 }
 
 shape ContactInfo {
-  email!: string @email()
-  phone?: string @regexp("^\\+?[1-9]\\d{1,14}$")  -- Optional phone
-  address?: Address  -- Optional address
+  email: string @email()
+  phone?: string @regexp("^\\+?[1-9]\\d{1,14}$")
+  address?: Address
 }
 
 shape User {
-  name!: string @minlength(2) @maxlength(100)
-  age: number @min(13) @max(120)  -- Can be null if unknown
-  contact!: ContactInfo
-  preferences?: dict[string]  -- Optional preferences
+  name: string @minlength(2) @maxlength(100)
+  age: number? @min(13) @max(120)
+  contact: ContactInfo
+  preferences?: dict[string]
 }
 ```
 
@@ -260,7 +274,7 @@ let user1: User = {
 -- User with minimal required fields (optional fields omitted)
 let user2: User = {
   name: "Jane Smith",
-  age: null,  -- Age unknown
+  age: null,  -- Age is nullable
   contact: {
     email: "jane@example.com"
     -- phone and address are optional, so omitted
@@ -352,15 +366,15 @@ Shapes defined in a policy are only available within that policy and **take prec
 namespace com/example/billing
 
 shape User {
-  id!: string @uuid()
-  email!: string @email()
+  id: string @uuid()
+  email: string @email()
 }
 
 policy process_payment_1 {
   -- Policy-local shape (most specific)
   shape User {
-    id!: string @uuid()
-    billing_address!: string
+    id: string @uuid()
+    billing_address: string
   }
 
   -- This resolves to the policy-local `User` shape
@@ -406,9 +420,9 @@ policy process_payment_2 {
 ```sentrie
 shape Category string @one_of("electronics", "clothing", "books", "home")
 shape Product {
-  name!: string @minlength(1) @maxlength(100) @not_empty()
-  price!: number @positive() @range(0.01, 999999.99)
-  category!: Category
+  name: string @minlength(1) @maxlength(100) @not_empty()
+  price: number @positive() @range(0.01, 999999.99)
+  category: Category
   in_stock: bool
 }
 ```

--- a/src/content/docs/reference/trinary.md
+++ b/src/content/docs/reference/trinary.md
@@ -99,7 +99,7 @@ let result4 = g or h  -- unknown
 
 ```sentrie
 shape User {
-  name!: string
+  name: string
   email?: string
   age?: number
 }
@@ -130,7 +130,7 @@ let is_verified: trinary = user.email is defined and
 
 ```sentrie
 shape Account {
-  username!: string
+  username: string
   email?: string
   verified: bool
 }

--- a/src/content/docs/reference/types-and-values.md
+++ b/src/content/docs/reference/types-and-values.md
@@ -63,6 +63,23 @@ let u: dict[number] = { "one": 1, "two": 2, "three": 3 }
 let u: record[string, number, bool] = ["one", 1, true]
 ```
 
+## Nullable Types
+
+Sentrie supports type-level nullability with a `?` suffix on type references.
+
+- `string?` -> value may be `null` or a string
+- `list[string]?` -> list itself may be `null`
+- `dict[string?]` -> dict values may be `null`
+- `Person?` -> shape value may be `null`
+
+```text
+let middleName: string? = null
+let tags: list[string]? = null
+let attrs: dict[string?] = {"nickname": null}
+```
+
+`T?` means **nullable value**. This is different from optional bindings (for example, `field?` in shapes/facts), which control whether a key may be absent.
+
 :::caution
 Map keys must be strings.
 :::

--- a/src/content/docs/reference/typescript_modules/index.md
+++ b/src/content/docs/reference/typescript_modules/index.md
@@ -13,8 +13,8 @@ Import and use built-in modules in your policies:
 namespace com/example/mypolicy
 
 policy mypolicy {
-  fact data!: string
-  fact timestamp!: number
+  fact data: string
+  fact timestamp: number
 
   use { now } from @sentrie/time
   use { sha256 } from @sentrie/hash
@@ -221,10 +221,10 @@ Functions for generating UUIDs (Universally Unique Identifiers).
 namespace com/example/auth
 
 policy authentication {
-  fact token!: string
-  fact secretKey!: string
-  fact passwordInput!: string
-  fact expectedHash!: string
+  fact token: string
+  fact secretKey: string
+  fact passwordInput: string
+  fact expectedHash: string
 
   use { sha256, hmac } from @sentrie/hash
   use { decode, verify } from @sentrie/jwt
@@ -251,8 +251,8 @@ policy authentication {
 namespace com/example/validation
 
 policy validation {
-  fact email!: string
-  fact jsonData!: string
+  fact email: string
+  fact jsonData: string
 
   use { match } from @sentrie/regex
   use { length } from @sentrie/js as str
@@ -279,9 +279,9 @@ policy validation {
 namespace com/example/network
 
 policy network {
-  fact clientIp!: string
-  fact allowedCidr!: string
-  fact requestUrl!: string
+  fact clientIp: string
+  fact allowedCidr: string
+  fact requestUrl: string
 
   use { cidrContains, isPrivate, parseIP } from @sentrie/net
   use { getHost, isValid } from @sentrie/url
@@ -310,8 +310,8 @@ policy network {
 namespace com/example/time
 
 policy time {
-  fact tokenExpiry!: number
-  fact sessionStart!: number
+  fact tokenExpiry: number
+  fact sessionStart: number
 
   use { now, isBefore, addDuration, format } from @sentrie/time
 

--- a/src/content/docs/reference/typescript_modules/sentrie/collection.md
+++ b/src/content/docs/reference/typescript_modules/sentrie/collection.md
@@ -317,8 +317,8 @@ let merged = collection.map_merge(user1, user2)  // {"name": "John", "age": 31, 
 namespace com/example/mypolicy
 
 policy mypolicy {
-  fact numbers!: list[number]
-  fact user!: document
+  fact numbers: list[number]
+  fact user: document
 
   use { list_includes, list_sort, map_keys, map_get } from @sentrie/collection
 

--- a/src/content/docs/reference/typescript_modules/sentrie/crypto.md
+++ b/src/content/docs/reference/typescript_modules/sentrie/crypto.md
@@ -31,8 +31,8 @@ Computes the SHA-256 hash of a string. This function uses a streaming hash imple
 namespace com/example/auth
 
 policy mypolicy {
-  fact passwordInput!: string
-  fact expectedHash!: string
+  fact passwordInput: string
+  fact expectedHash: string
 
   use { sha256 } from @sentrie/crypto
 

--- a/src/content/docs/reference/typescript_modules/sentrie/encoding.md
+++ b/src/content/docs/reference/typescript_modules/sentrie/encoding.md
@@ -164,7 +164,7 @@ let decoded = encoding.urlDecode("Hello%2C%20World%21")  // "Hello, World!"
 namespace com/example/mypolicy
 
 policy mypolicy {
-  fact data!: string
+  fact data: string
 
   use { base64Encode, base64Decode, urlEncode, urlDecode } from @sentrie/encoding
 

--- a/src/content/docs/reference/typescript_modules/sentrie/hash.md
+++ b/src/content/docs/reference/typescript_modules/sentrie/hash.md
@@ -114,11 +114,11 @@ let mac = hash.hmac("sha256", "Hello, World!", "secret-key")
 namespace com/example/auth
 
 policy mypolicy {
-  fact passwordInput!: string
-  fact expectedHash!: string
-  fact secretKey!: string
-  fact message!: string
-  fact expectedMac!: string
+  fact passwordInput: string
+  fact expectedHash: string
+  fact secretKey: string
+  fact message: string
+  fact expectedMac: string
 
   use { sha256, hmac } from @sentrie/hash
 

--- a/src/content/docs/reference/typescript_modules/sentrie/js.md
+++ b/src/content/docs/reference/typescript_modules/sentrie/js.md
@@ -453,8 +453,8 @@ let newArray = arr.of(1, 2, 3)  // [1, 2, 3]
 namespace com/example/mypolicy
 
 policy mypolicy {
-  fact price!: number
-  fact data!: string
+  fact price: number
+  fact data: string
 
   use { round, floor, ceil, max, min } from @sentrie/js as math
   use { length, fromCharCode } from @sentrie/js as str

--- a/src/content/docs/reference/typescript_modules/sentrie/json.md
+++ b/src/content/docs/reference/typescript_modules/sentrie/json.md
@@ -54,7 +54,7 @@ See the [@sentrie/js](/reference/typescript_modules/sentrie/js) documentation fo
 namespace com/example/mypolicy
 
 policy mypolicy {
-  fact data!: string
+  fact data: string
 
   use { isValid } from @sentrie/json as jsonUtil
   use { parse, stringify } from @sentrie/js as json

--- a/src/content/docs/reference/typescript_modules/sentrie/jwt.md
+++ b/src/content/docs/reference/typescript_modules/sentrie/jwt.md
@@ -104,8 +104,8 @@ let header = jwt.getHeader(token)
 namespace com/example/auth
 
 policy mypolicy {
-  fact token!: string
-  fact secretKey!: string
+  fact token: string
+  fact secretKey: string
 
   use { decode, verify } from @sentrie/jwt
 

--- a/src/content/docs/reference/typescript_modules/sentrie/net.md
+++ b/src/content/docs/reference/typescript_modules/sentrie/net.md
@@ -243,8 +243,8 @@ let isMulti = net.isMulticast("224.0.0.1")  // true
 namespace com/example/network
 
 policy mypolicy {
-  fact clientIp!: string
-  fact allowedCidr!: string
+  fact clientIp: string
+  fact allowedCidr: string
 
   use { cidrContains, parseIP, isPrivate, isPublic } from @sentrie/net
 

--- a/src/content/docs/reference/typescript_modules/sentrie/regex.md
+++ b/src/content/docs/reference/typescript_modules/sentrie/regex.md
@@ -143,8 +143,8 @@ let parts = regex.split("\\s+", "hello   world  test")  // ["hello", "world", "t
 namespace com/example/validation
 
 policy mypolicy {
-  fact email!: string
-  fact phoneNumber!: string
+  fact email: string
+  fact phoneNumber: string
 
   use { match, find, replaceAll } from @sentrie/regex
 

--- a/src/content/docs/reference/typescript_modules/sentrie/semver.md
+++ b/src/content/docs/reference/typescript_modules/sentrie/semver.md
@@ -198,9 +198,9 @@ let noMeta = semver.metadata("1.2.3")  // null
 namespace com/example/version
 
 policy mypolicy {
-  fact currentVersion!: string
-  fact requiredVersion!: string
-  fact versionConstraint!: string
+  fact currentVersion: string
+  fact requiredVersion: string
+  fact versionConstraint: string
 
   use { compare, satisfies, major, minor, patch } from @sentrie/semver
 

--- a/src/content/docs/reference/typescript_modules/sentrie/time.md
+++ b/src/content/docs/reference/typescript_modules/sentrie/time.md
@@ -211,7 +211,7 @@ Examples:
 namespace com/example/access
 
 policy mypolicy {
-  fact tokenExpiry!: number
+  fact tokenExpiry: number
 
   use { now, isBefore, addDuration, format } from @sentrie/time
 

--- a/src/content/docs/reference/typescript_modules/sentrie/url.md
+++ b/src/content/docs/reference/typescript_modules/sentrie/url.md
@@ -157,7 +157,7 @@ let invalid = url.isValid("not-a-url")  // false
 namespace com/example/validation
 
 policy mypolicy {
-  fact requestUrl!: string
+  fact requestUrl: string
 
   use { parse, getHost, getPath, isValid } from @sentrie/url
 

--- a/src/content/docs/reference/typescript_modules/sentrie/uuid.md
+++ b/src/content/docs/reference/typescript_modules/sentrie/uuid.md
@@ -82,7 +82,7 @@ let uuid = uuid.v7()  // Time-ordered UUID with Unix timestamp
 namespace com/example/resources
 
 policy mypolicy {
-  fact resourceType!: string
+  fact resourceType: string
 
   use { v4, v7 } from @sentrie/uuid
 

--- a/src/content/docs/reference/using-typescript.md
+++ b/src/content/docs/reference/using-typescript.md
@@ -38,8 +38,8 @@ shape User {
 }
 
 policy mypolicy {
-  fact user!: User
-  fact passwordInput!: string
+  fact user: User
+  fact passwordInput: string
 
   use { now } from @sentrie/time
   use { sha256 } from @sentrie/hash
@@ -95,9 +95,9 @@ shape User {
 }
 
 policy mypolicy {
-  fact user!: User
-  fact passwordInput!: string
-  fact userAge!: number
+  fact user: User
+  fact passwordInput: string
+  fact userAge: number
 
   use { md5, sha256 } from @sentrie/hash
   use { now } from @sentrie/time

--- a/src/content/docs/structure-of-a-policy-pack/typescript-file.mdx
+++ b/src/content/docs/structure-of-a-policy-pack/typescript-file.mdx
@@ -52,7 +52,7 @@ Use relative paths from the policy file location:
 namespace com/example/auth
 
 policy userAccess {
-  fact user!: User
+  fact user: User
 
   use { calculateAge, validateEmail } from "./utils.ts" as utils
 
@@ -79,7 +79,7 @@ Use `@local` prefix for paths relative to the pack root ([sentrie.pack.toml](/st
 namespace com/example/auth
 
 policy userAccess {
-  fact user!: User
+  fact user: User
 
   use { calculateAge } from "@local/utils/helpers" as helpers
 
@@ -285,15 +285,15 @@ Used in a policy (only functions are imported via `use`):
 namespace com/example/auth
 
 shape User {
-  id!: string
-  email!: string
-  birthDate!: string
-  passwordHash!: string
+  id: string
+  email: string
+  birthDate: string
+  passwordHash: string
 }
 
 policy userAccess {
-  fact user!: User
-  fact passwordInput!: string
+  fact user: User
+  fact passwordInput: string
 
   // Only functions can be imported via 'use' statement
   use { calculateAge, verifyPassword, isValidUser } from "./utils/user-helpers.ts" as userUtils


### PR DESCRIPTION

## Summary

- Aligns documentation with the language change: optionality on the binding (`field?`), nullability on the type (`T?`), and removal of `!`-based shape field forms.
- Refreshes examples across reference pages, TypeScript module samples, and policy-pack structure docs so they no longer teach legacy syntax.

## What this PR does

- Rewrites the shapes reference to document the four-way matrix (`field: T`, `field?: T`, `field: T?`, `field?: T?`), absent vs `null` behavior, migration from old bang syntax, and an Elvis example with optional fields.
- Adds a nullable types section to types-and-values (`string?`, containers, shape refs).
- Updates facts and policy reference to describe nullable fact types (`fact x: T?`, `fact x?: T?`) instead of “facts are always non-null.”
- Updates the language reference index shape section and fixes getting-started notes on facts.
- Applies the same syntax conventions to fan-out examples (built-ins, rules, TypeScript module pages, etc.).

## Changes by area

### Core reference

- `src/content/docs/reference/shapes.md`
- `src/content/docs/reference/types-and-values.md`
- `src/content/docs/reference/facts.md`
- `src/content/docs/reference/index.md`
- `src/content/docs/reference/policies.md`
- `src/content/docs/getting-started/writing-your-first-policy.md`

### Examples and modules

- Arithmetic, boolean, built-in functions, rules, trinary, using-typescript, structure-of-a-policy-pack.
- `typescript_modules/index.md` and per-module `sentrie/*.md` example snippets.

## Review notes

- Spot-check that no page still states bare `T` allows implicit `null` on shape fields.
- Cross-link shapes ↔ types-and-values ↔ facts for consistent wording on `undefined` vs `null` where relevant.

## Testing notes

- Documentation-only; preview site build if your pipeline requires it.

## Dependency changes

- None.
