### PR TITLE
Add derives reference page and overview links Closes #34

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -138,6 +138,10 @@ export default defineConfig({
               slug: "reference/rules",
             },
             {
+              label: "Derives",
+              slug: "reference/derives",
+            },
+            {
               label: "Exporting and Importing Rules",
               slug: "reference/exporting-and-importing-rules",
             },

--- a/src/content/docs/reference/built-in-functions.md
+++ b/src/content/docs/reference/built-in-functions.md
@@ -163,6 +163,8 @@ Builtins `any`, `all`, `filter`, `first`, `collect`, `reduce`, and `distinct` wo
 
 These operations return **new lists** (or scalars for `any`, `all`, `reduce`, `first`) and do not mutate the input.
 
+For `any`, `all`, `filter`, `first`, `collect`, and the two-argument `distinct` form, the callable may be an inline lambda or a **single-parameter derive** passed by name (for example `filter(items, is_valid)`). See [Derives](/reference/derives#callbacks-for-higher-order-builtins).
+
 The **`dict[T]`** type describes JSON-like objects with string keys and values of type `T`. List transforms use the **`collect(...)`** builtin; `dict[...]` is only for types.
 
 ### `any(list, predicate)`

--- a/src/content/docs/reference/derives.md
+++ b/src/content/docs/reference/derives.md
@@ -1,11 +1,13 @@
 ---
 title: "Derives"
-description: "Named pure functions (derives), resolution order with builtins, and export rules."
+description: "Named pure functions (derives), purity rules, HOF callbacks, visibility, and export rules."
 ---
 
 # Derives
 
 A **derive** is a named, pure function attached to a namespace or to a policy. Derives are written as a `derive` binding whose value is a **lambda** (the same `=>` block syntax used for collection builtins).
+
+Derives let you name reusable pure logic (predicates, mappers, small transforms) and call it from rules or from other derives. They are **not** a replacement for TypeScript modules: derive bodies must stay within Sentrie's pure subset and cannot call `use` modules.
 
 ## Syntax
 
@@ -22,30 +24,144 @@ Inside a policy body (after metadata, `fact`, and `use`—the same phase as `let
 derive NAME = LAMBDA
 ```
 
+Policy-level derives **cannot** be exported. `export derive NAME` is only valid at namespace scope; a policy body that tries to export a derive is rejected at parse time.
+
 The right-hand side must be a lambda expression, for example:
 
-```text
+```sentrie
 derive double = (x: number): number => {
   let t = x * 2
   yield t + 1
 }
 ```
 
+Typed parameters, optional parameters (`?`), and return types use the same lambda syntax documented under [Lambdas](/reference#lambdas). Duplicate parameter names in the same list are rejected at parse time.
+
 ## Calling derives
 
-- **Unqualified name**: `myDerive(arg1, arg2)` resolves **derive → builtin → TypeScript module** in that order. If a derive has the same name as a builtin, the derive wins (shadowing is allowed by design).
-- **Qualified slash callee**: `com/example/ns/myDerive(arg)` parses as a call whose target is the slash-separated path. This is distinct from binary division: `a / b` is division, while `com/example/ns/name(x)` is a call on the FQN-shaped callee.
+### Unqualified name
 
-## Purity and builtins
+`myDerive(arg1, arg2)` resolves **derive → builtin → TypeScript module** in that order. If a derive has the same name as a builtin, the derive wins (shadowing is allowed by design).
 
-Derive bodies may call only a **fixed whitelist** of builtins (plus other derives and TypeScript modules you `use`). Builtins that are not on the whitelist cannot be used from a derive because they cannot guarantee deterministic output within a single policy execution. The `now()` builtin is explicitly allowed: it returns the policy execution start time (`createdAt`), not wall-clock time per call, so it stays deterministic for the run.
+Inside a **rule** or other non-derive expression, an unqualified derive name is invoked with `(...)`.
+
+Inside another **derive** body, a visible derive must also be invoked as `otherDerive(...)` — not referenced as a bare identifier — except when passed as a callback to certain higher-order builtins (see [Callbacks](#callbacks-for-higher-order-builtins) below).
+
+### Qualified slash callee
+
+`com/example/ns/myDerive(arg)` parses as a call whose target is the slash-separated path. This is distinct from binary division: `a / b` is division, while `com/example/ns/name(x)` is a call on the FQN-shaped callee.
+
+Slash callees require at least three segments (for example `com/ex/helper`) so two-segment chains are not mistaken for division.
+
+## Visibility and scope
+
+### Namespace-scoped derives
+
+Declared at namespace scope. Visible to policies and other derives in the same namespace according to the derive's bind-time snapshot (`DefineShort` / `DefineFQN`).
+
+Cross-namespace access by slash FQN requires `export derive NAME` at namespace scope, same as shapes.
+
+### Policy-scoped derives
+
+Declared inside a policy body. Visible only within **that policy** — not to other policies in the same namespace, and not to namespace-scoped derives.
+
+A rule in `com/ex/polB` cannot call `com/ex/polA/secret()` even when both policies share the namespace. Index validation and runtime both enforce this boundary.
+
+Resolution order for an unqualified name in a policy prefers a **policy-local** derive over a namespace derive with the same name.
+
+## Purity rules
+
+Derive bodies are validated statically and enforced at runtime. A derive must be **deterministic within a single policy execution**.
+
+### Allowed
+
+- Parameters, `let` bindings in the derive body, and pure builtin calls from the whitelist below
+- Calls to other **visible** derives (by name or slash FQN, subject to scope and export rules)
+- Inline lambdas passed as arguments to pure builtins (for example `filter(items, (x) => { yield x > 0 })`)
+- Single-parameter derives passed as callbacks to higher-order pure builtins (see below)
+
+### Not allowed
+
+- **TypeScript module calls** (`alias.fn(...)`) — including modules imported with `use`
+- **Facts** — fact identifiers are not available inside a derive
+- **Rules** — rules cannot be referenced or dispatched from inside a derive
+- **Callable return values** — a derive cannot `yield` a lambda or other callable value
+- **Non-whitelisted builtins** — builtins outside the pure set cannot be used from a derive
+
+The `now()` builtin is explicitly allowed: it returns the policy execution start time (`createdAt`), not wall-clock time per call, so it stays deterministic for the run.
+
+### Pure builtin whitelist
+
+Derive bodies may call only these builtins (plus other visible derives):
+
+`all`, `any`, `as_list`, `collect`, `count`, `distinct`, `error`, `filter`, `first`, `flatten`, `flatten_deep`, `merge`, `normalise_list`, `now`, `reduce`
+
+Argument and return types are checked at invoke time; type mismatches include the **parameter name** in the error.
+
+## Callbacks for higher-order builtins
+
+Single-parameter derives may be passed **by identifier** as the callable argument to these pure builtins:
+
+`any`, `all`, `filter`, `first`, `collect`, `distinct` (two-argument form with a key selector)
+
+Example:
+
+```sentrie
+derive is_available = (item: number): trinary => {
+  yield item > 0
+}
+
+policy inventory {
+  let _seed = 0
+  rule check = {
+    yield any([1, 2, 3], is_available)
+  }
+  export decision of check
+}
+```
+
+Multi-parameter derives used as callbacks must be wrapped in an inline lambda if the builtin's arity contract requires it. A derive with zero required parameters cannot be used as an iterator callback (`any` / `filter` expect arity 1 or 2).
 
 ## Exports
 
-`export derive NAME` marks a namespace-level derive as exportable for cross-namespace references when policy rules call it by fully qualified name (subject to the same visibility rules as other exports).
+`export derive NAME` marks a **namespace-level** derive as exportable for cross-namespace slash-FQN references from rules (subject to the same visibility rules as exported shapes).
+
+Policy-scoped derives are never exported; they are private to their policy.
+
+## Examples
+
+Namespace helper used from a policy rule:
+
+```sentrie
+namespace com/example/shop
+
+derive above = (n: number, min: number): trinary => {
+  yield n > min
+}
+
+policy pricing {
+  let _seed = 0
+  rule ok = { yield above(100, 50) }
+  export decision of ok
+}
+```
+
+Policy-local derive with slash FQN to a sibling in the same policy:
+
+```sentrie
+namespace com/example/shop
+
+policy cart {
+  let _seed = 0
+  derive unit = () => { yield 1 }
+  derive total = () => { yield com/example/shop/cart/unit() + 1 }
+  rule gate = { yield total() == 2 }
+  export decision of gate
+}
+```
 
 ## See also
 
-- [Lambdas](/reference#lambdas) — parameter lists, optional parameters, and return types
-- [Built-in functions](/reference/built-in-functions) — collection helpers that accept lambdas
-- [Using TypeScript](/reference/using-typescript) — `use` modules from derives
+- [Lambdas](/reference#lambdas) — parameter lists, optional parameters, return types, and arity for builtins
+- [Built-in functions](/reference/built-in-functions) — collection helpers that accept lambdas or derive callbacks
+- [Using TypeScript](/reference/using-typescript) — TypeScript modules in **rules** and `let` expressions (not inside derive bodies)

--- a/src/content/docs/reference/derives.md
+++ b/src/content/docs/reference/derives.md
@@ -1,0 +1,51 @@
+---
+title: "Derives"
+description: "Named pure functions (derives), resolution order with builtins, and export rules."
+---
+
+# Derives
+
+A **derive** is a named, pure function attached to a namespace or to a policy. Derives are written as a `derive` binding whose value is a **lambda** (the same `=>` block syntax used for collection builtins).
+
+## Syntax
+
+At namespace scope (alongside policies and shapes):
+
+```text
+derive NAME = LAMBDA
+export derive NAME
+```
+
+Inside a policy body (after metadata, `fact`, and `use`—the same phase as `let`, `rule`, and `shape`):
+
+```text
+derive NAME = LAMBDA
+```
+
+The right-hand side must be a lambda expression, for example:
+
+```text
+derive double = (x: number): number => {
+  let t = x * 2
+  yield t + 1
+}
+```
+
+## Calling derives
+
+- **Unqualified name**: `myDerive(arg1, arg2)` resolves **derive → builtin → TypeScript module** in that order. If a derive has the same name as a builtin, the derive wins (shadowing is allowed by design).
+- **Qualified slash callee**: `com/example/ns/myDerive(arg)` parses as a call whose target is the slash-separated path. This is distinct from binary division: `a / b` is division, while `com/example/ns/name(x)` is a call on the FQN-shaped callee.
+
+## Purity and builtins
+
+Derive bodies may call only a **fixed whitelist** of builtins (plus other derives and TypeScript modules you `use`). Builtins that are not on the whitelist cannot be used from a derive because they cannot guarantee deterministic output within a single policy execution. The `now()` builtin is explicitly allowed: it returns the policy execution start time (`createdAt`), not wall-clock time per call, so it stays deterministic for the run.
+
+## Exports
+
+`export derive NAME` marks a namespace-level derive as exportable for cross-namespace references when policy rules call it by fully qualified name (subject to the same visibility rules as other exports).
+
+## See also
+
+- [Lambdas](/reference#lambdas) — parameter lists, optional parameters, and return types
+- [Built-in functions](/reference/built-in-functions) — collection helpers that accept lambdas
+- [Using TypeScript](/reference/using-typescript) — `use` modules from derives

--- a/src/content/docs/reference/index.md
+++ b/src/content/docs/reference/index.md
@@ -13,6 +13,7 @@ This is the complete reference for the Sentrie policy language. It covers all la
 - [Rules](#rules)
 - [Expressions](#expressions)
 - [Lambdas](#lambdas) - Callable syntax (`=>`) for passing functions as values to builtins
+- [Derives](/reference/derives) - Named pure functions (`derive`) and export rules
 - [Primitives, Collections, Shapes, and Aliases](#primitives-collections-shapes-and-aliases)
 - [Literals](#literals)
 - [Operators](#operators)
@@ -28,7 +29,7 @@ This is the complete reference for the Sentrie policy language. It covers all la
 A Sentrie program consists of:
 
 1. **Namespace declaration** (required)
-2. **Top-level declarations** (policies, shapes)
+2. **Top-level declarations** (policies, shapes, derives, exports)
 3. **Comments** (anywhere)
 
 ```text
@@ -43,7 +44,12 @@ shape User {
   -- shape definition
 }
 
+derive helper = (x: number) => {
+  yield x + 1
+}
+
 export shape User -- export shapes to allow visibility to other namespaces
+export derive helper
 ```
 
 ## Namespaces
@@ -70,7 +76,9 @@ A namespace can contain:
 
 - **policies**: `policy IDENT { ... }`
 - **shapes**: `shape IDENT { ... }`
+- **derives**: `derive IDENT = LAMBDA`
 - **shape exports**: `export shape IDENT`
+- **derive exports**: `export derive IDENT`
 
 ### Rules
 
@@ -321,6 +329,22 @@ Lambdas **capture** the surrounding execution context: names visible where the l
 
 Callable values are **not** ordinary JSON-like data. They cannot be passed through every runtime boundary that expects plain data (for example some module or interop paths that materialize `[]any` or JSON). Prefer keeping lambdas and callables inside policy evaluation; if you need to pass data out, convert to plain values first.
 
+### Typed parameters and return types
+
+You can annotate lambda parameters and the return value:
+
+```sentrie
+(a: number, b?: string): number => {
+  yield a + (count(b) as number)
+}
+```
+
+Optional parameters use `?` after the name (for example `b?`). A required parameter cannot follow an optional one; that ordering is rejected at parse time.
+
+## Derives
+
+**Derives** are named pure functions at namespace or policy scope. They reuse lambda syntax and are documented in the dedicated [Derives](/reference/derives) page (calling rules, FQN slash callees, builtin whitelist, and exports).
+
 ## Primitives, Collections, Shapes, and Aliases
 
 Sentrie provides primitives, collections, shapes, and aliases for defining data structures.
@@ -470,6 +494,14 @@ null        -- Null value
 ```
 
 ## Operators
+
+### Elvis operator (`?:`)
+
+```text
+a ?: b
+```
+
+If `a` is **`null`** or **`undefined`**, the expression evaluates to **`b`** (and `b` is evaluated). For any other value of `a` (including `0`, `""`, or `false`), the result is **`a`** and **`b` is not evaluated**. This matches common “default for missing” patterns for facts and optional parameters.
 
 ### Arithmetic Operators
 

--- a/src/content/docs/reference/index.md
+++ b/src/content/docs/reference/index.md
@@ -311,6 +311,8 @@ let sum: number = reduce(nums, 0, (acc, n) => {
 })
 ```
 
+Single-parameter **derives** can also be passed by name to `any`, `all`, `filter`, `first`, `collect`, and the two-argument `distinct` form — see [Derives](/reference/derives#callbacks-for-higher-order-builtins).
+
 Which builtin you use determines how many parameters the lambda should take (its **arity**), for example:
 
 - **`any`**, **`all`**, **`filter`**, **`first`**, **`collect`**: arity **1** (element only) or **2** (element and index).


### PR DESCRIPTION
## Summary
- Rewrites the derives reference page to match runtime and index behavior from issue #88.
- Removes incorrect guidance that TypeScript modules may be called from derive bodies.
- Documents purity rules, policy scope, HOF callbacks, and export constraints.

## What this PR does
- Corrects `derives.md` so derive purity explicitly forbids TypeScript/`use` module calls.
- Adds visibility rules for namespace vs policy-scoped derives and cross-policy FQN boundaries.
- Documents single-parameter derive callbacks for collection builtins.
- Cross-links lambdas and built-in functions pages to the derive callback section.

## Changes By Area

### Reference documentation
- **`src/content/docs/reference/derives.md`**: Full rewrite — syntax, calling, scope, purity whitelist, callbacks, exports, examples, corrected See also links.
- **`src/content/docs/reference/index.md`**: Lambdas section notes derive callbacks for HOF builtins.
- **`src/content/docs/reference/built-in-functions.md`**: List builtins section notes derive-by-name callbacks.

## Review Notes
- Verify prose matches sentrie branch `88-add-derive-for-named-pure-expressions-using-typed-lambda-syntax` behavior (no TS in derives, policy scope, export rules).
- Confirm examples use valid Sentrie syntax and three-segment slash FQNs where shown.

## Testing Notes
- Docs-only change; preview site pages `/reference/derives`, `/reference`, and `/reference/built-in-functions`.

## Dependency changes
- None
